### PR TITLE
New Control: NumericUpDown family

### DIFF
--- a/demo/Ursa.Demo/Models/MenuKeys.cs
+++ b/demo/Ursa.Demo/Models/MenuKeys.cs
@@ -14,6 +14,7 @@ public static class MenuKeys
     public const string MenuKeyKeyGestureInput = "KeyGestureInput";
     public const string MenuKeyLoading = "Loading";
     public const string MenuKeyNavigation = "Navigation";
+    public const string MenuKeyNumericUpDown = "NumericUpDown";
     public const string MenuKeyPagination = "Pagination";
     public const string MenuKeyTagInput = "TagInput";
     public const string MenuKeyTimeline = "Timeline";

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
@@ -14,13 +14,13 @@
         </Style>
     </UserControl.Styles>
     <StackPanel HorizontalAlignment="Left">
-        <u:NumericIntUpDown Name="input" Step="1" Value="2" Watermark="Input Value" />
+        <u:NumericIntUpDown Name="input" Step="1" Value="2" Watermark="Input Value" IsReadOnly="True" />
         <TextBlock Text="{Binding #input.Value}" ></TextBlock>
         <u:NumericDoubleUpDown Name="inputDouble" Step="0.5" Value="3.1" EmptyInputValue="1"></u:NumericDoubleUpDown>
         <TextBlock Text="{Binding #inputDouble.Value}"></TextBlock>
         <u:NumericByteUpDown Name="inputByte" Step="1" Value="3" EmptyInputValue="1"></u:NumericByteUpDown>
         <TextBlock Text="{Binding #inputByte.Value}"></TextBlock>
         <TextBlock Text="Drag"></TextBlock>
-        <u:NumericIntUpDown  Step="1" Value="2" Watermark="Input Value" IsTextEditable="False" />
+        <u:NumericIntUpDown  Step="1" Value="2" Watermark="Input Value" AllowDrag="True" />
     </StackPanel>
 </UserControl>

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
@@ -1,0 +1,14 @@
+﻿<UserControl
+    x:Class="Ursa.Demo.Pages.NumericUpDownDemo"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:u="https://irihi.tech/ursa"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
+    <StackPanel>
+        <u:IntUpDown />
+    </StackPanel>
+</UserControl>

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
@@ -14,7 +14,7 @@
         </Style>
     </UserControl.Styles>
     <StackPanel HorizontalAlignment="Left">
-        <u:NumericIntUpDown Name="input" Step="1" Value="2" Watermark="Input Value" IsReadOnly="True" />
+        <u:NumericIntUpDown Name="input" Step="1" Value="2" Watermark="Input Value" Classes="ClearButton" />
         <TextBlock Text="{Binding #input.Value}" ></TextBlock>
         <u:NumericDoubleUpDown Name="inputDouble" Step="0.5" Value="3.1" EmptyInputValue="1"></u:NumericDoubleUpDown>
         <TextBlock Text="{Binding #inputDouble.Value}"></TextBlock>

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
@@ -21,6 +21,6 @@
         <u:NumericByteUpDown Name="inputByte" Step="1" Value="3" EmptyInputValue="1"></u:NumericByteUpDown>
         <TextBlock Text="{Binding #inputByte.Value}"></TextBlock>
         <TextBlock Text="Drag"></TextBlock>
-        <u:NumericIntUpDown  Step="1" Value="2" Watermark="Input Value" TextEditable="False" />
+        <u:NumericIntUpDown  Step="1" Value="2" Watermark="Input Value" IsTextEditable="False" />
     </StackPanel>
 </UserControl>

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
@@ -8,14 +8,19 @@
     d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d">
-    <StackPanel>
-        <u:IntUpDown Name="input" Step="1" Value="2" Watermark="Input Value" />
+    <UserControl.Styles>
+        <Style Selector=":is(u|NumericUpDown)">
+            <Setter Property="Width" Value="240"></Setter>
+        </Style>
+    </UserControl.Styles>
+    <StackPanel HorizontalAlignment="Left">
+        <u:NumericIntUpDown Name="input" Step="1" Value="2" Watermark="Input Value" />
         <TextBlock Text="{Binding #input.Value}" ></TextBlock>
-        <u:DoubleUpDown Name="inputDouble" Step="0.5" Value="3.1" EmptyInputValue="1"></u:DoubleUpDown>
+        <u:NumericDoubleUpDown Name="inputDouble" Step="0.5" Value="3.1" EmptyInputValue="1"></u:NumericDoubleUpDown>
         <TextBlock Text="{Binding #inputDouble.Value}"></TextBlock>
-        <u:ByteUpDown Name="inputByte" Step="1" Value="3" EmptyInputValue="1"></u:ByteUpDown>
+        <u:NumericByteUpDown Name="inputByte" Step="1" Value="3" EmptyInputValue="1"></u:NumericByteUpDown>
         <TextBlock Text="{Binding #inputByte.Value}"></TextBlock>
         <TextBlock Text="Drag"></TextBlock>
-        <u:IntUpDown  Step="1" Value="2" Watermark="Input Value" TextEditable="False" />
+        <u:NumericIntUpDown  Step="1" Value="2" Watermark="Input Value" TextEditable="False" />
     </StackPanel>
 </UserControl>

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
@@ -14,7 +14,7 @@
         </Style>
     </UserControl.Styles>
     <StackPanel HorizontalAlignment="Left">
-        <u:NumericIntUpDown Name="input" Step="1" Value="2" Watermark="Input Value" Classes="ClearButton" />
+        <u:NumericIntUpDown Name="input" InnerLeftContent="Age" Step="1" Value="2" Watermark="Input Value" Classes="ClearButton" />
         <TextBlock Text="{Binding #input.Value}" ></TextBlock>
         <u:NumericDoubleUpDown Name="inputDouble" Step="0.5" Value="3.1" EmptyInputValue="1"></u:NumericDoubleUpDown>
         <TextBlock Text="{Binding #inputDouble.Value}"></TextBlock>

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
@@ -9,6 +9,7 @@
     d:DesignWidth="800"
     mc:Ignorable="d">
     <StackPanel>
-        <u:IntUpDown />
+        <u:IntUpDown Name="input" Step="1" Value="2" EmptyInputValue="0" />
+        <TextBlock Text="{Binding #input.Value}" ></TextBlock>
     </StackPanel>
 </UserControl>

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml
@@ -9,7 +9,13 @@
     d:DesignWidth="800"
     mc:Ignorable="d">
     <StackPanel>
-        <u:IntUpDown Name="input" Step="1" Value="2" EmptyInputValue="0" />
+        <u:IntUpDown Name="input" Step="1" Value="2" Watermark="Input Value" />
         <TextBlock Text="{Binding #input.Value}" ></TextBlock>
+        <u:DoubleUpDown Name="inputDouble" Step="0.5" Value="3.1" EmptyInputValue="1"></u:DoubleUpDown>
+        <TextBlock Text="{Binding #inputDouble.Value}"></TextBlock>
+        <u:ByteUpDown Name="inputByte" Step="1" Value="3" EmptyInputValue="1"></u:ByteUpDown>
+        <TextBlock Text="{Binding #inputByte.Value}"></TextBlock>
+        <TextBlock Text="Drag"></TextBlock>
+        <u:IntUpDown  Step="1" Value="2" Watermark="Input Value" TextEditable="False" />
     </StackPanel>
 </UserControl>

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml.cs
@@ -1,0 +1,15 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Ursa.Demo.ViewModels;
+
+namespace Ursa.Demo.Pages;
+
+public partial class NumericUpDownDemo : UserControl
+{
+    public NumericUpDownDemo()
+    {
+        InitializeComponent();
+        DataContext = new NumericUpDownDemoViewModel();
+    }
+}

--- a/demo/Ursa.Demo/ViewModels/MainViewViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/MainViewViewModel.cs
@@ -36,6 +36,7 @@ public class MainViewViewModel : ViewModelBase
             MenuKeys.MenuKeyKeyGestureInput => new KeyGestureInputDemoViewModel(),
             MenuKeys.MenuKeyLoading => new LoadingDemoViewModel(),
             MenuKeys.MenuKeyNavigation => new NavigationMenuDemoViewModel(),
+            MenuKeys.MenuKeyNumericUpDown => new NumericUpDownDemoViewModel(),
             MenuKeys.MenuKeyPagination => new PaginationDemoViewModel(),
             MenuKeys.MenuKeyTagInput => new TagInputDemoViewModel(),
             MenuKeys.MenuKeyTimeline => new TimelineDemoViewModel(),

--- a/demo/Ursa.Demo/ViewModels/MenuViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/MenuViewModel.cs
@@ -23,6 +23,7 @@ public class MenuViewModel: ViewModelBase
             new() { MenuHeader = "KeyGestureInput", Key = MenuKeys.MenuKeyKeyGestureInput },
             new() { MenuHeader = "Loading", Key = MenuKeys.MenuKeyLoading },
             new() { MenuHeader = "Navigation", Key = MenuKeys.MenuKeyNavigation },
+            new() { MenuHeader = "NumericUpDown", Key = MenuKeys.MenuKeyNumericUpDown },
             new() { MenuHeader = "Pagination", Key = MenuKeys.MenuKeyPagination },
             new() { MenuHeader = "TagInput", Key = MenuKeys.MenuKeyTagInput },
             new() { MenuHeader = "Timeline", Key = MenuKeys.MenuKeyTimeline },

--- a/demo/Ursa.Demo/ViewModels/NumericUpDownDemoViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/NumericUpDownDemoViewModel.cs
@@ -1,0 +1,8 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Ursa.Demo.ViewModels;
+
+public class NumericUpDownDemoViewModel: ObservableObject
+{
+    
+}

--- a/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
+++ b/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
@@ -1,0 +1,12 @@
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:u="https://irihi.tech/ursa">
+    <!-- Add Resources Here -->
+    <ControlTheme x:Key="{x:Type u:NumericUpDown}" TargetType="{x:Type u:NumericUpDown}">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Rectangle Fill="Red" Width="100" Height="100"></Rectangle>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
+++ b/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
@@ -38,8 +38,7 @@
                                 VerticalAlignment="Stretch"
                                 Background="Transparent"
                                 Cursor="SizeAll"
-                                IsVisible="{TemplateBinding IsTextEditable,
-                                                            Converter={x:Static BoolConverters.Not}}" />
+                                IsVisible="{TemplateBinding AllowDrag}" />
                         </Panel>
                     </ButtonSpinner>
                 </DataValidationErrors>

--- a/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
+++ b/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
@@ -3,9 +3,36 @@
                     xmlns:u="https://irihi.tech/ursa">
     <!-- Add Resources Here -->
     <ControlTheme x:Key="{x:Type u:NumericUpDown}" TargetType="{x:Type u:NumericUpDown}">
+        <Setter Property="NumericUpDown.VerticalContentAlignment" Value="Center" />
+        <Setter Property="NumericUpDown.CornerRadius" Value="{DynamicResource NumericUpDownCornerRadius}" />
         <Setter Property="Template">
-            <ControlTemplate>
-                <Rectangle Fill="Red" Width="100" Height="100"></Rectangle>
+            <ControlTemplate TargetType="u:NumericUpDown">
+                <DataValidationErrors>
+                    <ButtonSpinner
+                        Name="PART_Spinner"
+                        MinWidth="0"
+                        HorizontalContentAlignment="Stretch"
+                        VerticalContentAlignment="Stretch"
+                        AllowSpin="{TemplateBinding AllowSpin}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        >
+                        <TextBox
+                            Name="PART_TextBox"
+                            Height="{TemplateBinding Height}"
+                            MinHeight="{DynamicResource NumericUpDownWrapperDefaultHeight}"
+                            AcceptsReturn="False"
+                            CornerRadius="{TemplateBinding CornerRadius}"
+                            DataValidationErrors.Errors="{ReflectionBinding $parent[NumericUpDown].(DataValidationErrors.Errors)}"
+                            FontSize="{TemplateBinding FontSize}"
+                            Foreground="{TemplateBinding Foreground}"
+                            IsReadOnly="{TemplateBinding IsReadOnly}"
+                            TextWrapping="NoWrap"
+                            Theme="{DynamicResource NonErrorTextBox}"
+                            Watermark="{TemplateBinding Watermark}" />
+                    </ButtonSpinner>
+                </DataValidationErrors>
             </ControlTemplate>
         </Setter>
     </ControlTheme>

--- a/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
+++ b/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
@@ -1,7 +1,8 @@
-﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:u="https://irihi.tech/ursa">
-    <!-- Add Resources Here -->
+﻿<ResourceDictionary
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:u="https://irihi.tech/ursa">
+    <!--  Add Resources Here  -->
     <ControlTheme x:Key="{x:Type u:NumericUpDown}" TargetType="{x:Type u:NumericUpDown}">
         <Setter Property="NumericUpDown.VerticalContentAlignment" Value="Center" />
         <Setter Property="NumericUpDown.CornerRadius" Value="{DynamicResource NumericUpDownCornerRadius}" />
@@ -16,21 +17,30 @@
                         AllowSpin="{TemplateBinding AllowSpin}"
                         Background="{TemplateBinding Background}"
                         BorderBrush="{TemplateBinding BorderBrush}"
-                        BorderThickness="{TemplateBinding BorderThickness}"
-                        >
-                        <TextBox
-                            Name="PART_TextBox"
-                            Height="{TemplateBinding Height}"
-                            MinHeight="{DynamicResource NumericUpDownWrapperDefaultHeight}"
-                            AcceptsReturn="False"
-                            CornerRadius="{TemplateBinding CornerRadius}"
-                            DataValidationErrors.Errors="{ReflectionBinding $parent[NumericUpDown].(DataValidationErrors.Errors)}"
-                            FontSize="{TemplateBinding FontSize}"
-                            Foreground="{TemplateBinding Foreground}"
-                            IsReadOnly="{TemplateBinding IsReadOnly}"
-                            TextWrapping="NoWrap"
-                            Theme="{DynamicResource NonErrorTextBox}"
-                            Watermark="{TemplateBinding Watermark}" />
+                        BorderThickness="{TemplateBinding BorderThickness}">
+                        <Panel>
+                            <TextBox
+                                Name="PART_TextBox"
+                                Height="{TemplateBinding Height}"
+                                MinHeight="{DynamicResource NumericUpDownWrapperDefaultHeight}"
+                                AcceptsReturn="False"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                DataValidationErrors.Errors="{ReflectionBinding $parent[NumericUpDown].(DataValidationErrors.Errors)}"
+                                FontSize="{TemplateBinding FontSize}"
+                                Foreground="{TemplateBinding Foreground}"
+                                IsReadOnly="{TemplateBinding IsReadOnly}"
+                                TextWrapping="NoWrap"
+                                Theme="{DynamicResource NonErrorTextBox}"
+                                Watermark="{TemplateBinding Watermark}" />
+                            <Panel
+                                Name="PART_DragPanel"
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                Background="Transparent"
+                                Cursor="SizeAll"
+                                IsVisible="{TemplateBinding TextEditable,
+                                                            Converter={x:Static BoolConverters.Not}}" />
+                        </Panel>
                     </ButtonSpinner>
                 </DataValidationErrors>
             </ControlTemplate>

--- a/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
+++ b/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
@@ -51,6 +51,7 @@
                                 Foreground="{TemplateBinding Foreground}"
                                 IsReadOnly="{TemplateBinding IsReadOnly}"
                                 TextWrapping="NoWrap"
+                                InnerLeftContent="{TemplateBinding InnerLeftContent}"
                                 Theme="{DynamicResource NonErrorTextBox}"
                                 Watermark="{TemplateBinding Watermark}" />
                             <Panel

--- a/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
+++ b/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
@@ -38,7 +38,7 @@
                                 VerticalAlignment="Stretch"
                                 Background="Transparent"
                                 Cursor="SizeAll"
-                                IsVisible="{TemplateBinding TextEditable,
+                                IsVisible="{TemplateBinding IsTextEditable,
                                                             Converter={x:Static BoolConverters.Not}}" />
                         </Panel>
                     </ButtonSpinner>

--- a/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
+++ b/src/Ursa.Themes.Semi/Controls/NumericUpDown.axaml
@@ -3,6 +3,27 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:u="https://irihi.tech/ursa">
     <!--  Add Resources Here  -->
+    
+    <ControlTheme x:Key="InputClearButton" TargetType="Button">
+        <Setter Property="Button.Foreground" Value="{DynamicResource TextBoxButtonDefaultForeground}" />
+        <Setter Property="Button.Cursor" Value="Hand" />
+        <Setter Property="Button.Template">
+            <ControlTemplate TargetType="Button">
+                <!--  Background must be transparent or hit test will fail  -->
+                <ContentControl Background="Transparent">
+                    <PathIcon
+                        Width="16"
+                        Height="16"
+                        Data="{DynamicResource TextBoxClearButtonData}"
+                        Foreground="{TemplateBinding Foreground}" />
+                </ContentControl>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover">
+            <Setter Property="Foreground" Value="{DynamicResource TextBoxButtonPointeroverForeground}" />
+        </Style>
+    </ControlTheme>
+    
     <ControlTheme x:Key="{x:Type u:NumericUpDown}" TargetType="{x:Type u:NumericUpDown}">
         <Setter Property="NumericUpDown.VerticalContentAlignment" Value="Center" />
         <Setter Property="NumericUpDown.CornerRadius" Value="{DynamicResource NumericUpDownCornerRadius}" />
@@ -39,10 +60,27 @@
                                 Background="Transparent"
                                 Cursor="SizeAll"
                                 IsVisible="{TemplateBinding AllowDrag}" />
+                            <Button
+                                Name="PART_ClearButton"
+                                Command="{Binding $parent[u:NumericUpDown].Clear}"
+                                HorizontalAlignment="Right"
+                                Margin="0 0 8 0"
+                                IsVisible="False"
+                                Focusable="False"
+                                Theme="{StaticResource InputClearButton}" />
                         </Panel>
                     </ButtonSpinner>
                 </DataValidationErrors>
             </ControlTemplate>
         </Setter>
+        
+        <Style Selector="^.clearButton, ^.ClearButton">
+            <Style Selector="^[IsReadOnly=False]:focus /template/ Button#PART_ClearButton">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+            <Style Selector="^[IsReadOnly=False]:pointerover /template/ Button#PART_ClearButton">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+        </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Controls/_index.axaml
+++ b/src/Ursa.Themes.Semi/Controls/_index.axaml
@@ -12,6 +12,7 @@
         <ResourceInclude Source="KeyGestureInput.axaml" />
         <ResourceInclude Source="Loading.axaml" />
         <ResourceInclude Source="Navigation.axaml" />
+        <ResourceInclude Source="NumericUpDown.axaml" />
         <ResourceInclude Source="Pagination.axaml" />
         <ResourceInclude Source="TagInput.axaml" />
         <ResourceInclude Source="Timeline.axaml" />

--- a/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
+++ b/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
@@ -1,48 +1,32 @@
-﻿using Avalonia.Utilities;
+﻿using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Utilities;
 
 namespace Ursa.Controls;
 
-public class IntUpDown: NumericUpDownBase<int>
+public class IntUpDown : NumericUpDownBase<int>
 {
     protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
 
     static IntUpDown()
     {
         MaximumProperty.OverrideDefaultValue<IntUpDown>(int.MaxValue);
+        MinimumProperty.OverrideDefaultValue<IntUpDown>(int.MinValue);
         StepProperty.OverrideDefaultValue<IntUpDown>(1);
     }
-    
-    protected override void Increase()
+
+    protected override bool ParseText(string? text, out int? number)
     {
-        Value += Step;
+        var result = int.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
+        number = value;
+        return result;
     }
 
-    protected override void Decrease()
-    {
-        Value -= Step;
-    }
-    
-    protected override void UpdateTextToValue(string x)
-    {
-        if (int.TryParse(x, out var value))
-        {
-            Value = value;
-        }
-    }
+    protected override string? ValueToString(int? value) => value?.ToString(FormatString, NumberFormat);
 
-    protected override bool CommitInput()
-    {
-        // throw new NotImplementedException();
-        return true;
-    }
+    protected override int Zero => 0;
 
-    protected override void SyncTextAndValue()
-    {
-        // throw new NotImplementedException();
-    }
+    protected override int? Add(int? a, int? b) => a + b;
 
-    protected override int Clamp()
-    {
-        return MathUtilities.Clamp(Value, Maximum, Minimum);
-    }
+    protected override int? Minus(int? a, int? b) => a - b;
 }

--- a/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
+++ b/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
@@ -44,8 +44,7 @@ public class NumericDoubleUpDown : NumericUpDownBase<double>
 
     protected override bool ParseText(string? text, out double? number)
     {
-        // Weird bug
-        var result = double.TryParse(text, out var value);
+        var result = double.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
         number = value;
         return result;
     }

--- a/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
+++ b/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
@@ -4,15 +4,15 @@ using Avalonia.Utilities;
 
 namespace Ursa.Controls;
 
-public class IntUpDown : NumericUpDownBase<int>
+public class NumericIntUpDown : NumericUpDownBase<int>
 {
     protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
 
-    static IntUpDown()
+    static NumericIntUpDown()
     {
-        MaximumProperty.OverrideDefaultValue<IntUpDown>(int.MaxValue);
-        MinimumProperty.OverrideDefaultValue<IntUpDown>(int.MinValue);
-        StepProperty.OverrideDefaultValue<IntUpDown>(1);
+        MaximumProperty.OverrideDefaultValue<NumericIntUpDown>(int.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericIntUpDown>(int.MinValue);
+        StepProperty.OverrideDefaultValue<NumericIntUpDown>(1);
     }
 
     protected override bool ParseText(string? text, out int? number)
@@ -31,15 +31,15 @@ public class IntUpDown : NumericUpDownBase<int>
     protected override int? Minus(int? a, int? b) => a - b;
 }
 
-public class DoubleUpDown : NumericUpDownBase<double>
+public class NumericDoubleUpDown : NumericUpDownBase<double>
 {
     protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
 
-    static DoubleUpDown()
+    static NumericDoubleUpDown()
     {
-        MaximumProperty.OverrideDefaultValue<DoubleUpDown>(double.MaxValue);
-        MinimumProperty.OverrideDefaultValue<DoubleUpDown>(double.MinValue);
-        StepProperty.OverrideDefaultValue<DoubleUpDown>(1);
+        MaximumProperty.OverrideDefaultValue<NumericDoubleUpDown>(double.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericDoubleUpDown>(double.MinValue);
+        StepProperty.OverrideDefaultValue<NumericDoubleUpDown>(1);
     }
 
     protected override bool ParseText(string? text, out double? number)
@@ -59,15 +59,15 @@ public class DoubleUpDown : NumericUpDownBase<double>
     protected override double? Minus(double? a, double? b) => a - b;
 }
 
-public class ByteUpDown : NumericUpDownBase<byte>
+public class NumericByteUpDown : NumericUpDownBase<byte>
 {
     protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
 
-    static ByteUpDown()
+    static NumericByteUpDown()
     {
-        MaximumProperty.OverrideDefaultValue<ByteUpDown>(byte.MaxValue);
-        MinimumProperty.OverrideDefaultValue<ByteUpDown>(byte.MinValue);
-        StepProperty.OverrideDefaultValue<ByteUpDown>(1);
+        MaximumProperty.OverrideDefaultValue<NumericByteUpDown>(byte.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericByteUpDown>(byte.MinValue);
+        StepProperty.OverrideDefaultValue<NumericByteUpDown>(1);
     }
 
     protected override bool ParseText(string? text, out byte? number)
@@ -85,3 +85,193 @@ public class ByteUpDown : NumericUpDownBase<byte>
 
     protected override byte? Minus(byte? a, byte? b) => (byte?) (a - b);
 }
+
+public class NumericSByteUpDown : NumericUpDownBase<sbyte>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static NumericSByteUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<NumericSByteUpDown>(sbyte.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericSByteUpDown>(sbyte.MinValue);
+        StepProperty.OverrideDefaultValue<NumericSByteUpDown>(1);
+    }
+
+    protected override bool ParseText(string? text, out sbyte? number)
+    {
+        var result = sbyte.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
+        number = value;
+        return result;
+    }
+
+    protected override string? ValueToString(sbyte? value) => value?.ToString(FormatString, NumberFormat);
+
+    protected override sbyte Zero => 0;
+
+    protected override sbyte? Add(sbyte? a, sbyte? b) => (sbyte?) (a + b);
+
+    protected override sbyte? Minus(sbyte? a, sbyte? b) => (sbyte?) (a - b);
+}
+
+public class NumericShortUpDown : NumericUpDownBase<short>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static NumericShortUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<NumericShortUpDown>(short.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericShortUpDown>(short.MinValue);
+        StepProperty.OverrideDefaultValue<NumericShortUpDown>(1);
+    }
+
+    protected override bool ParseText(string? text, out short? number)
+    {
+        var result = short.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
+        number = value;
+        return result;
+    }
+
+    protected override string? ValueToString(short? value) => value?.ToString(FormatString, NumberFormat);
+
+    protected override short Zero => 0;
+
+    protected override short? Add(short? a, short? b) => (short?) (a + b);
+
+    protected override short? Minus(short? a, short? b) => (short?) (a - b);
+}
+
+public class NumericUShortUpDown : NumericUpDownBase<ushort>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static NumericUShortUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<NumericUShortUpDown>(ushort.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericUShortUpDown>(ushort.MinValue);
+        StepProperty.OverrideDefaultValue<NumericUShortUpDown>(1);
+    }
+
+    protected override bool ParseText(string? text, out ushort? number)
+    {
+        var result = ushort.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
+        number = value;
+        return result;
+    }
+
+    protected override string? ValueToString(ushort? value) => value?.ToString(FormatString, NumberFormat);
+
+    protected override ushort Zero => 0;
+
+    protected override ushort? Add(ushort? a, ushort? b) => (ushort?) (a + b);
+
+    protected override ushort? Minus(ushort? a, ushort? b) => (ushort?) (a - b);
+}
+
+public class NumericLongUpDown : NumericUpDownBase<long>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static NumericLongUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<NumericLongUpDown>(long.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericLongUpDown>(long.MinValue);
+        StepProperty.OverrideDefaultValue<NumericLongUpDown>(1);
+    }
+
+    protected override bool ParseText(string? text, out long? number)
+    {
+        var result = long.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
+        number = value;
+        return result;
+    }
+
+    protected override string? ValueToString(long? value) => value?.ToString(FormatString, NumberFormat);
+
+    protected override long Zero => 0;
+
+    protected override long? Add(long? a, long? b) => a + b;
+
+    protected override long? Minus(long? a, long? b) => a - b;
+}
+
+public class NumericULongUpDown : NumericUpDownBase<ulong>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static NumericULongUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<NumericULongUpDown>(ulong.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericULongUpDown>(ulong.MinValue);
+        StepProperty.OverrideDefaultValue<NumericULongUpDown>(1);
+    }
+
+    protected override bool ParseText(string? text, out ulong? number)
+    {
+        var result = ulong.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
+        number = value;
+        return result;
+    }
+
+    protected override string? ValueToString(ulong? value) => value?.ToString(FormatString, NumberFormat);
+
+    protected override ulong Zero => 0;
+
+    protected override ulong? Add(ulong? a, ulong? b) => a + b;
+
+    protected override ulong? Minus(ulong? a, ulong? b) => a - b;
+}
+
+public class NumericFloatUpDown : NumericUpDownBase<float>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static NumericFloatUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<NumericFloatUpDown>(float.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericFloatUpDown>(float.MinValue);
+        StepProperty.OverrideDefaultValue<NumericFloatUpDown>(1);
+    }
+
+    protected override bool ParseText(string? text, out float? number)
+    {
+        var result = float.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
+        number = value;
+        return result;
+    }
+
+    protected override string? ValueToString(float? value) => value?.ToString(FormatString, NumberFormat);
+
+    protected override float Zero => 0;
+
+    protected override float? Add(float? a, float? b) => a + b;
+
+    protected override float? Minus(float? a, float? b) => a - b;
+}
+
+public class NumericDecimalUpDown : NumericUpDownBase<decimal>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static NumericDecimalUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<NumericDecimalUpDown>(decimal.MaxValue);
+        MinimumProperty.OverrideDefaultValue<NumericDecimalUpDown>(decimal.MinValue);
+        StepProperty.OverrideDefaultValue<NumericDecimalUpDown>(1);
+    }
+
+    protected override bool ParseText(string? text, out decimal? number)
+    {
+        var result = decimal.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
+        number = value;
+        return result;
+    }
+
+    protected override string? ValueToString(decimal? value) => value?.ToString(FormatString, NumberFormat);
+
+    protected override decimal Zero => 0;
+
+    protected override decimal? Add(decimal? a, decimal? b) => a + b;
+
+    protected override decimal? Minus(decimal? a, decimal? b) => a - b;
+}
+

--- a/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
+++ b/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
@@ -15,12 +15,8 @@ public class NumericIntUpDown : NumericUpDownBase<int>
         StepProperty.OverrideDefaultValue<NumericIntUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out int? number)
-    {
-        var result = int.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out int number) =>
+        int.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(int? value) => value?.ToString(FormatString, NumberFormat);
 
@@ -42,12 +38,8 @@ public class NumericDoubleUpDown : NumericUpDownBase<double>
         StepProperty.OverrideDefaultValue<NumericDoubleUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out double? number)
-    {
-        var result = double.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out double number) =>
+        double.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(double? value) => value?.ToString(FormatString, NumberFormat);
 
@@ -69,12 +61,8 @@ public class NumericByteUpDown : NumericUpDownBase<byte>
         StepProperty.OverrideDefaultValue<NumericByteUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out byte? number)
-    {
-        var result = byte.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out byte number) =>
+        byte.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(byte? value) => value?.ToString(FormatString, NumberFormat);
 
@@ -96,12 +84,8 @@ public class NumericSByteUpDown : NumericUpDownBase<sbyte>
         StepProperty.OverrideDefaultValue<NumericSByteUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out sbyte? number)
-    {
-        var result = sbyte.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out sbyte number) =>
+        sbyte.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(sbyte? value) => value?.ToString(FormatString, NumberFormat);
 
@@ -123,12 +107,8 @@ public class NumericShortUpDown : NumericUpDownBase<short>
         StepProperty.OverrideDefaultValue<NumericShortUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out short? number)
-    {
-        var result = short.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out short number) =>
+        short.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(short? value) => value?.ToString(FormatString, NumberFormat);
 
@@ -150,12 +130,8 @@ public class NumericUShortUpDown : NumericUpDownBase<ushort>
         StepProperty.OverrideDefaultValue<NumericUShortUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out ushort? number)
-    {
-        var result = ushort.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out ushort number) =>
+        ushort.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(ushort? value) => value?.ToString(FormatString, NumberFormat);
 
@@ -177,12 +153,8 @@ public class NumericLongUpDown : NumericUpDownBase<long>
         StepProperty.OverrideDefaultValue<NumericLongUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out long? number)
-    {
-        var result = long.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out long number) =>
+        long.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(long? value) => value?.ToString(FormatString, NumberFormat);
 
@@ -204,12 +176,8 @@ public class NumericULongUpDown : NumericUpDownBase<ulong>
         StepProperty.OverrideDefaultValue<NumericULongUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out ulong? number)
-    {
-        var result = ulong.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out ulong number) =>
+        ulong.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(ulong? value) => value?.ToString(FormatString, NumberFormat);
 
@@ -231,12 +199,8 @@ public class NumericFloatUpDown : NumericUpDownBase<float>
         StepProperty.OverrideDefaultValue<NumericFloatUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out float? number)
-    {
-        var result = float.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out float number) =>
+        float.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(float? value) => value?.ToString(FormatString, NumberFormat);
 
@@ -258,12 +222,8 @@ public class NumericDecimalUpDown : NumericUpDownBase<decimal>
         StepProperty.OverrideDefaultValue<NumericDecimalUpDown>(1);
     }
 
-    protected override bool ParseText(string? text, out decimal? number)
-    {
-        var result = decimal.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
-        number = value;
-        return result;
-    }
+    protected override bool ParseText(string? text, out decimal number) =>
+        decimal.TryParse(text, ParsingNumberStyle, NumberFormat, out number);
 
     protected override string? ValueToString(decimal? value) => value?.ToString(FormatString, NumberFormat);
 

--- a/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
+++ b/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
@@ -1,0 +1,22 @@
+﻿namespace Ursa.Controls;
+
+public class IntUpDown: NumericUpDownBase<int>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static IntUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<IntUpDown>(100);
+    }
+    
+    protected override void Increase()
+    {
+        //throw new NotImplementedException();
+        Value += Maximum;
+    }
+
+    protected override void Decrease()
+    {
+        Value -= Maximum;
+    }
+}

--- a/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
+++ b/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
@@ -1,4 +1,6 @@
-﻿namespace Ursa.Controls;
+﻿using Avalonia.Utilities;
+
+namespace Ursa.Controls;
 
 public class IntUpDown: NumericUpDownBase<int>
 {
@@ -6,17 +8,41 @@ public class IntUpDown: NumericUpDownBase<int>
 
     static IntUpDown()
     {
-        MaximumProperty.OverrideDefaultValue<IntUpDown>(100);
+        MaximumProperty.OverrideDefaultValue<IntUpDown>(int.MaxValue);
+        StepProperty.OverrideDefaultValue<IntUpDown>(1);
     }
     
     protected override void Increase()
     {
-        //throw new NotImplementedException();
-        Value += Maximum;
+        Value += Step;
     }
 
     protected override void Decrease()
     {
-        Value -= Maximum;
+        Value -= Step;
+    }
+    
+    protected override void UpdateTextToValue(string x)
+    {
+        if (int.TryParse(x, out var value))
+        {
+            Value = value;
+        }
+    }
+
+    protected override bool CommitInput()
+    {
+        // throw new NotImplementedException();
+        return true;
+    }
+
+    protected override void SyncTextAndValue()
+    {
+        // throw new NotImplementedException();
+    }
+
+    protected override int Clamp()
+    {
+        return MathUtilities.Clamp(Value, Maximum, Minimum);
     }
 }

--- a/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
+++ b/src/Ursa/Controls/NumericUpDown/IntUpDown.cs
@@ -30,3 +30,58 @@ public class IntUpDown : NumericUpDownBase<int>
 
     protected override int? Minus(int? a, int? b) => a - b;
 }
+
+public class DoubleUpDown : NumericUpDownBase<double>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static DoubleUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<DoubleUpDown>(double.MaxValue);
+        MinimumProperty.OverrideDefaultValue<DoubleUpDown>(double.MinValue);
+        StepProperty.OverrideDefaultValue<DoubleUpDown>(1);
+    }
+
+    protected override bool ParseText(string? text, out double? number)
+    {
+        // Weird bug
+        var result = double.TryParse(text, out var value);
+        number = value;
+        return result;
+    }
+
+    protected override string? ValueToString(double? value) => value?.ToString(FormatString, NumberFormat);
+
+    protected override double Zero => 0;
+
+    protected override double? Add(double? a, double? b) => a + b;
+
+    protected override double? Minus(double? a, double? b) => a - b;
+}
+
+public class ByteUpDown : NumericUpDownBase<byte>
+{
+    protected override Type StyleKeyOverride { get; } = typeof(NumericUpDown);
+
+    static ByteUpDown()
+    {
+        MaximumProperty.OverrideDefaultValue<ByteUpDown>(byte.MaxValue);
+        MinimumProperty.OverrideDefaultValue<ByteUpDown>(byte.MinValue);
+        StepProperty.OverrideDefaultValue<ByteUpDown>(1);
+    }
+
+    protected override bool ParseText(string? text, out byte? number)
+    {
+        var result = byte.TryParse(text, ParsingNumberStyle, NumberFormat, out var value);
+        number = value;
+        return result;
+    }
+
+    protected override string? ValueToString(byte? value) => value?.ToString(FormatString, NumberFormat);
+
+    protected override byte Zero => 0;
+
+    protected override byte? Add(byte? a, byte? b) => (byte?) (a + b);
+
+    protected override byte? Minus(byte? a, byte? b) => (byte?) (a - b);
+}

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -1,0 +1,133 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Primitives;
+
+namespace Ursa.Controls;
+
+[TemplatePart(PART_Spinner, typeof(ButtonSpinner))]
+[TemplatePart(PART_TextBox, typeof(TextBox))]
+public abstract class NumericUpDown : TemplatedControl
+{
+    public const string PART_Spinner = "PART_Spinner";
+    public const string PART_TextBox = "PART_TextBox";
+    
+    private Avalonia.Controls.NumericUpDown? _numericUpDown;
+    private ButtonSpinner? _spinner;
+    private TextBox? _textBox;
+    
+    public static readonly StyledProperty<bool> TextEditableProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
+        nameof(TextEditable), defaultValue: true);
+
+    public bool TextEditable
+    {
+        get => GetValue(TextEditableProperty);
+        set => SetValue(TextEditableProperty, value);
+    }
+
+    public static readonly StyledProperty<bool> IsReadOnlyProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
+        nameof(IsReadOnly));
+
+    public bool IsReadOnly
+    {
+        get => GetValue(IsReadOnlyProperty);
+        set => SetValue(IsReadOnlyProperty, value);
+    }
+
+    public static readonly StyledProperty<object?> InnerLeftContentProperty = AvaloniaProperty.Register<NumericUpDown, object?>(
+        nameof(InnerLeftContent));
+
+    public object? InnerLeftContent
+    {
+        get => GetValue(InnerLeftContentProperty);
+        set => SetValue(InnerLeftContentProperty, value);
+    }
+
+    public static readonly StyledProperty<string?> WatermarkProperty = AvaloniaProperty.Register<NumericUpDown, string?>(
+        nameof(Watermark));
+
+    public string? Watermark
+    {
+        get => GetValue(WatermarkProperty);
+        set => SetValue(WatermarkProperty, value);
+    }
+    
+    
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+        if(_spinner is not null)
+        {
+            _spinner.Spin -= OnSpin;
+        }
+        if(_textBox is not null)
+        {
+            _textBox.TextChanged -= OnTextChange;
+        }
+        _spinner = e.NameScope.Find<ButtonSpinner>(PART_Spinner);
+        _textBox = e.NameScope.Find<TextBox>(PART_TextBox);
+        if (_spinner is not null)
+        {
+            _spinner.Spin += OnSpin;
+        }
+
+        if (_textBox is not null)
+        {
+            _textBox.TextChanged += OnTextChange;
+        }
+        
+    }
+
+    private void OnTextChange(object sender, TextChangedEventArgs e)
+    {
+        
+        
+    }
+
+    private void OnSpin(object sender, SpinEventArgs e)
+    {
+        if (e.Direction == SpinDirection.Increase)
+        {
+            Increase();
+        }
+        else
+        {
+            Decrease();
+        }
+    }
+
+    protected abstract void Increase();
+    protected abstract void Decrease();
+}
+
+public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComparable<T>
+{
+    public static readonly StyledProperty<T> ValueProperty = AvaloniaProperty.Register<NumericUpDownBase<T>, T>(
+        nameof(Value));
+
+    public T Value
+    {
+        get => GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+
+    public static readonly StyledProperty<T> MaximumProperty = AvaloniaProperty.Register<NumericUpDownBase<T>, T>(
+        nameof(Maximum));
+
+    public T Maximum
+    {
+        get => GetValue(MaximumProperty);
+        set => SetValue(MaximumProperty, value);
+    }
+
+    public static readonly StyledProperty<T> MinimumProperty = AvaloniaProperty.Register<NumericUpDownBase<T>, T>(
+        nameof(Minimum));
+
+    public T Minimum
+    {
+        get => GetValue(MinimumProperty);
+        set => SetValue(MinimumProperty, value);
+    }
+    
+    
+}

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -2,19 +2,26 @@
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
 
 namespace Ursa.Controls;
 
 [TemplatePart(PART_Spinner, typeof(ButtonSpinner))]
 [TemplatePart(PART_TextBox, typeof(TextBox))]
+[TemplatePart(PART_DragPanel, typeof(Panel))]
 public abstract class NumericUpDown : TemplatedControl
 {
     public const string PART_Spinner = "PART_Spinner";
     public const string PART_TextBox = "PART_TextBox";
+    public const string PART_DragPanel = "PART_DragPanel";
     
-    private Avalonia.Controls.NumericUpDown? _numericUpDown;
-    private ButtonSpinner? _spinner;
-    private TextBox? _textBox;
+    protected internal ButtonSpinner? _spinner;
+    protected internal TextBox? _textBox;
+    protected internal Panel? _dragPanel;
+
+    private Point? _point;
+    private bool _updateFromTextInput;
     
     public static readonly StyledProperty<bool> TextEditableProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
         nameof(TextEditable), defaultValue: true);
@@ -64,6 +71,13 @@ public abstract class NumericUpDown : TemplatedControl
         {
             _textBox.TextChanged -= OnTextChange;
         }
+
+        if (_dragPanel is not null)
+        {
+            _dragPanel.PointerPressed -= OnDragPanelPointerPressed;
+            _dragPanel.PointerMoved -= OnDragPanelPointerMoved;
+            _dragPanel.PointerReleased -= OnDragPanelPointerReleased;
+        }
         _spinner = e.NameScope.Find<ButtonSpinner>(PART_Spinner);
         _textBox = e.NameScope.Find<TextBox>(PART_TextBox);
         if (_spinner is not null)
@@ -75,13 +89,56 @@ public abstract class NumericUpDown : TemplatedControl
         {
             _textBox.TextChanged += OnTextChange;
         }
+
+        if (_dragPanel is not null)
+        {
+            _dragPanel.PointerPressed+= OnDragPanelPointerPressed;
+            _dragPanel.PointerMoved += OnDragPanelPointerMoved;
+            _dragPanel.PointerReleased += OnDragPanelPointerReleased;
+        }
         
+    }
+
+    protected override void OnLostFocus(RoutedEventArgs e)
+    {
+        CommitInput();
+        base.OnLostFocus(e);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Enter)
+        {
+            var commitSuccess = CommitInput();
+            e.Handled = !commitSuccess;
+        }
+    }
+
+    private void OnDragPanelPointerPressed(object sender, PointerPressedEventArgs e)
+    {
+        _point = e.GetPosition(this);
+    }
+    
+    private void OnDragPanelPointerReleased(object sender, PointerReleasedEventArgs e)
+    {
+        _point = null;
+    }
+    
+    private void OnDragPanelPointerMoved(object sender, PointerEventArgs e)
+    {
+        var point = e.GetPosition(this);
+        var delta = point - _point;
+        if (delta is null)
+        {
+            return;
+        }
     }
 
     private void OnTextChange(object sender, TextChangedEventArgs e)
     {
-        
-        
+        _updateFromTextInput = true;
+        UpdateTextToValue(_textBox?.Text ?? string.Empty);
+        _updateFromTextInput = false;
     }
 
     private void OnSpin(object sender, SpinEventArgs e)
@@ -98,6 +155,9 @@ public abstract class NumericUpDown : TemplatedControl
 
     protected abstract void Increase();
     protected abstract void Decrease();
+    protected abstract void UpdateTextToValue(string x);
+    protected abstract bool CommitInput();
+    protected abstract void SyncTextAndValue();
 }
 
 public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComparable<T>
@@ -128,6 +188,15 @@ public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComp
         get => GetValue(MinimumProperty);
         set => SetValue(MinimumProperty, value);
     }
-    
-    
+
+    public static readonly StyledProperty<T> StepProperty = AvaloniaProperty.Register<NumericUpDownBase<T>, T>(
+        nameof(Step));
+
+    public T Step
+    {
+        get => GetValue(StepProperty);
+        set => SetValue(StepProperty, value);
+    }
+
+    protected abstract T Clamp();
 }

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -82,7 +82,7 @@ public abstract class NumericUpDown : TemplatedControl
     }
 
     public static readonly StyledProperty<NumberStyles> ParsingNumberStyleProperty = AvaloniaProperty.Register<NumericUpDown, NumberStyles>(
-        nameof(ParsingNumberStyle));
+        nameof(ParsingNumberStyle), defaultValue: NumberStyles.Any);
 
     public NumberStyles ParsingNumberStyle
     {

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -290,6 +290,8 @@ public abstract class NumericUpDown : TemplatedControl
 
     protected abstract bool SyncTextAndValue(bool fromTextToValue = false, string? text = null,
         bool forceTextUpdate = false);
+
+    public abstract void Clear();
 }
 
 public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComparable<T>
@@ -613,4 +615,9 @@ public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComp
     protected abstract T? Add(T? a, T? b);
     protected abstract T? Minus(T? a, T? b);
 
+    public override void Clear()
+    {
+        SetCurrentValue(ValueProperty, EmptyInputValue);
+        SyncTextAndValue(false, forceTextUpdate: true);
+    }
 }

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -1,7 +1,10 @@
-﻿using Avalonia;
+﻿using System.Globalization;
+using System.Net.Mime;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data.Converters;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 
@@ -21,7 +24,7 @@ public abstract class NumericUpDown : TemplatedControl
     protected internal Panel? _dragPanel;
 
     private Point? _point;
-    private bool _updateFromTextInput;
+    protected internal bool _updateFromTextInput;
     
     public static readonly StyledProperty<bool> TextEditableProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
         nameof(TextEditable), defaultValue: true);
@@ -58,8 +61,94 @@ public abstract class NumericUpDown : TemplatedControl
         get => GetValue(WatermarkProperty);
         set => SetValue(WatermarkProperty, value);
     }
+
+    public static readonly StyledProperty<NumberFormatInfo?> NumberFormatProperty = AvaloniaProperty.Register<NumericUpDown, NumberFormatInfo?>(
+        nameof(NumberFormat), defaultValue: NumberFormatInfo.CurrentInfo);
+
+    public NumberFormatInfo? NumberFormat
+    {
+        get => GetValue(NumberFormatProperty);
+        set => SetValue(NumberFormatProperty, value);
+    }
+
+    public static readonly StyledProperty<string> FormatStringProperty = AvaloniaProperty.Register<NumericUpDown, string>(
+        nameof(FormatString), string.Empty);
+
+    public string FormatString
+    {
+        get => GetValue(FormatStringProperty);
+        set => SetValue(FormatStringProperty, value);
+    }
+
+    public static readonly StyledProperty<NumberStyles> ParsingNumberStyleProperty = AvaloniaProperty.Register<NumericUpDown, NumberStyles>(
+        nameof(ParsingNumberStyle));
+
+    public NumberStyles ParsingNumberStyle
+    {
+        get => GetValue(ParsingNumberStyleProperty);
+        set => SetValue(ParsingNumberStyleProperty, value);
+    }
+
+    public static readonly StyledProperty<IValueConverter?> TextConverterProperty = AvaloniaProperty.Register<NumericUpDown, IValueConverter?>(
+        nameof(TextConverter));
+
+    public IValueConverter? TextConverter
+    {
+        get => GetValue(TextConverterProperty);
+        set => SetValue(TextConverterProperty, value);
+    }
+
+    public static readonly StyledProperty<bool> AllowSpinProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
+        nameof(AllowSpin), true);
+
+    public bool AllowSpin
+    {
+        get => GetValue(AllowSpinProperty);
+        set => SetValue(AllowSpinProperty, value);
+    }
+
+    public static readonly StyledProperty<bool> AllowMouseWheelProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
+        nameof(AllowMouseWheel));
+
+    public bool AllowMouseWheel
+    {
+        get => GetValue(AllowMouseWheelProperty);
+        set => SetValue(AllowMouseWheelProperty, value);
+    }
+
+    public event EventHandler<SpinEventArgs>? Spinned;
     
-    
+    static NumericUpDown()
+    {
+        NumberFormatProperty.Changed.AddClassHandler<NumericUpDown>((o, e) => o.OnFormatChange(e));
+        FormatStringProperty.Changed.AddClassHandler<NumericUpDown>((o, e) => o.OnFormatChange(e));
+        IsReadOnlyProperty.Changed.AddClassHandler<NumericUpDown>((o,e)=>o.ChangeToSetSpinDirection(e));
+        TextConverterProperty.Changed.AddClassHandler<NumericUpDown>((o, e) => o.OnFormatChange(e));
+    }
+
+    protected void ChangeToSetSpinDirection(AvaloniaPropertyChangedEventArgs avaloniaPropertyChangedEventArgs, bool afterInitialization = false)
+    {
+        if (afterInitialization)
+        {
+            if (IsInitialized)
+            {
+                SetValidSpinDirection();
+            }
+        }
+        else
+        {
+            SetValidSpinDirection();
+        }
+    }
+
+    protected virtual void OnFormatChange(AvaloniaPropertyChangedEventArgs arg)
+    {
+        if (IsInitialized)
+        {
+            SyncTextAndValue(false, null);
+        }
+    }
+
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
@@ -70,6 +159,7 @@ public abstract class NumericUpDown : TemplatedControl
         if(_textBox is not null)
         {
             _textBox.TextChanged -= OnTextChange;
+            
         }
 
         if (_dragPanel is not null)
@@ -101,7 +191,7 @@ public abstract class NumericUpDown : TemplatedControl
 
     protected override void OnLostFocus(RoutedEventArgs e)
     {
-        CommitInput();
+        CommitInput(true);
         base.OnLostFocus(e);
     }
 
@@ -134,46 +224,65 @@ public abstract class NumericUpDown : TemplatedControl
         }
     }
 
+    [Obsolete]
     private void OnTextChange(object sender, TextChangedEventArgs e)
     {
         _updateFromTextInput = true;
-        UpdateTextToValue(_textBox?.Text ?? string.Empty);
+        SyncTextAndValue();
         _updateFromTextInput = false;
     }
 
     private void OnSpin(object sender, SpinEventArgs e)
     {
-        if (e.Direction == SpinDirection.Increase)
+        if (AllowSpin && !IsReadOnly)
         {
-            Increase();
-        }
-        else
-        {
-            Decrease();
+            var spin = !e.UsingMouseWheel;
+            spin |= _textBox is { IsFocused: true };
+            if (spin)
+            {
+                e.Handled = true;
+                var handler = Spinned;
+                handler?.Invoke(this, e);
+                if (e.Direction == SpinDirection.Increase)
+                {
+                    Increase();
+                }
+                else
+                {
+                    Decrease();
+                }
+            }
         }
     }
 
+    protected abstract void SetValidSpinDirection();
+
     protected abstract void Increase();
     protected abstract void Decrease();
-    protected abstract void UpdateTextToValue(string x);
-    protected abstract bool CommitInput();
-    protected abstract void SyncTextAndValue();
+
+    protected virtual bool CommitInput(bool forceTextUpdate = false)
+    {
+        return SyncTextAndValue(true, _textBox?.Text, forceTextUpdate);
+    }
+
+    protected abstract bool SyncTextAndValue(bool fromTextToValue = false, string? text = null,
+        bool forceTextUpdate = false);
 }
 
 public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComparable<T>
 {
-    public static readonly StyledProperty<T> ValueProperty = AvaloniaProperty.Register<NumericUpDownBase<T>, T>(
+    public static readonly StyledProperty<T?> ValueProperty = AvaloniaProperty.Register<NumericUpDownBase<T>, T?>(
         nameof(Value));
 
-    public T Value
+    public T? Value
     {
         get => GetValue(ValueProperty);
         set => SetValue(ValueProperty, value);
     }
 
     public static readonly StyledProperty<T> MaximumProperty = AvaloniaProperty.Register<NumericUpDownBase<T>, T>(
-        nameof(Maximum));
-
+        nameof(Maximum), coerce: CoerceMaximum);
+    
     public T Maximum
     {
         get => GetValue(MaximumProperty);
@@ -181,13 +290,54 @@ public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComp
     }
 
     public static readonly StyledProperty<T> MinimumProperty = AvaloniaProperty.Register<NumericUpDownBase<T>, T>(
-        nameof(Minimum));
+        nameof(Minimum), coerce: CoerceMinimum);
 
     public T Minimum
     {
         get => GetValue(MinimumProperty);
         set => SetValue(MinimumProperty, value);
     }
+    
+    #region Max and Min Coerce
+    private static T CoerceMaximum(AvaloniaObject instance, T value)
+    {
+        if (instance is NumericUpDownBase<T> n)
+        {
+            return n.CoerceMaximum(value);
+        }
+
+        return value;
+    } 
+    
+    private T CoerceMaximum(T value) 
+    {
+        if (value.CompareTo(Minimum) < 0)
+        {
+            return Minimum;
+        }
+        return value;
+    }
+    
+    private static T CoerceMinimum(AvaloniaObject instance, T value)
+    {
+        if (instance is NumericUpDownBase<T> n)
+        {
+            return n.CoerceMinimum(value);
+        }
+
+        return value;
+    }
+    
+    private T CoerceMinimum(T value) 
+    {
+        if (value.CompareTo(Maximum) > 0)
+        {
+            return Maximum;
+        }
+        return value;
+    }
+    
+    #endregion
 
     public static readonly StyledProperty<T> StepProperty = AvaloniaProperty.Register<NumericUpDownBase<T>, T>(
         nameof(Step));
@@ -198,5 +348,245 @@ public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComp
         set => SetValue(StepProperty, value);
     }
 
-    protected abstract T Clamp();
+    public static readonly StyledProperty<T?> EmptyInputValueProperty =
+        AvaloniaProperty.Register<NumericUpDownBase<T>, T?>(
+            nameof(EmptyInputValue), defaultValue: null);
+
+    public T? EmptyInputValue
+    {
+        get => GetValue(EmptyInputValueProperty);
+        set => SetValue(EmptyInputValueProperty, value);
+    }
+    
+    /// <summary>
+    /// Defines the <see cref="ValueChanged"/> event.
+    /// </summary>
+    public static readonly RoutedEvent<ValueChangedEventArgs<T>> ValueChangedEvent =
+        RoutedEvent.Register<NumericUpDown, ValueChangedEventArgs<T>>(nameof(ValueChanged), RoutingStrategies.Bubble);
+
+    /// <summary>
+    /// Raised when the <see cref="Value"/> changes.
+    /// </summary>
+    public event EventHandler<ValueChangedEventArgs<T>>? ValueChanged
+    {
+        add => AddHandler(ValueChangedEvent, value);
+        remove => RemoveHandler(ValueChangedEvent, value);
+    }
+
+    static NumericUpDownBase()
+    {
+        StepProperty.Changed.AddClassHandler<NumericUpDownBase<T>>((o, e) => o.ChangeToSetSpinDirection(e));
+        MaximumProperty.Changed.AddClassHandler<NumericUpDownBase<T>>((o, e) => o.OnConstraintChanged(e));
+        MinimumProperty.Changed.AddClassHandler<NumericUpDownBase<T>>((o, e) => o.OnConstraintChanged(e));
+        ValueProperty.Changed.AddClassHandler<NumericUpDownBase<T>>((o, e) => o.OnValueChanged(e) );
+    }
+    
+    private void OnConstraintChanged(AvaloniaPropertyChangedEventArgs avaloniaPropertyChangedEventArgs)
+    {
+        if (IsInitialized)
+        {
+            SetValidSpinDirection();
+        }
+        if (Value.HasValue)
+        {
+            SetCurrentValue(ValueProperty, Clamp(Value, Maximum, Minimum));
+        }
+    }
+    
+    private void OnValueChanged(AvaloniaPropertyChangedEventArgs args)
+    {
+        if (IsInitialized)
+        {
+            SyncTextAndValue(false, null, true);
+        }
+        SetValidSpinDirection();
+        T? oldValue = args.GetOldValue<T?>();
+        T? newValue = args.GetNewValue<T?>();
+        var e = new ValueChangedEventArgs<T>(ValueChangedEvent, oldValue, newValue);
+        RaiseEvent(e);
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+        if (_textBox != null)
+        {
+            _textBox.Text = ConvertValueToText(Value);
+        }
+    }
+
+    protected virtual T? Clamp(T? value, T max, T min)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+        if (value.Value.CompareTo(max) > 0)
+        {
+            return Maximum;
+        }
+        if (value.Value.CompareTo(min) < 0)
+        {
+            return Minimum;
+        }
+        return value;
+    }
+    
+    protected override void SetValidSpinDirection()
+    {
+        var validDirection = ValidSpinDirections.None;
+        if (!IsReadOnly)
+        {
+            if (Value is null)
+            {
+                validDirection = ValidSpinDirections.Increase | ValidSpinDirections.Decrease;
+            }
+            if (Value.HasValue && Value.Value.CompareTo(Maximum) < 0)
+            {
+                validDirection |= ValidSpinDirections.Increase;
+            }
+
+            if (Value.HasValue && Value.Value.CompareTo(Minimum) > 0)
+            {
+                validDirection |= ValidSpinDirections.Decrease;
+            }
+        }
+        if (_spinner != null)
+        {
+            _spinner.ValidSpinDirection = validDirection;
+        }
+    }
+
+    private bool _isSyncingTextAndValue;
+    
+    protected override bool SyncTextAndValue(bool fromTextToValue = false, string? text = null, bool forceTextUpdate = false)
+    {
+        if (_isSyncingTextAndValue) return true;
+        _isSyncingTextAndValue = true;
+        var parsedTextIsValid = true;
+        try
+        {
+            if (fromTextToValue)
+            {
+                try
+                {
+                    // TODO
+                    var newValue = ConvertTextToValue(text);
+                    if (EmptyInputValue is not null && newValue is null)
+                    {
+                        newValue = EmptyInputValue;
+                    }
+                    if (!Equals(newValue, Value))
+                    {
+                        SetCurrentValue(ValueProperty, newValue);
+                    }
+                }
+                catch
+                {
+                    parsedTextIsValid = false;
+                }
+            }
+
+            if (!_updateFromTextInput)
+            {
+                if (forceTextUpdate)
+                {
+                    var newText = ConvertValueToText(Value);
+                    if (_textBox!= null && !Equals(_textBox.Text, newText))
+                    {
+                        _textBox.Text = newText;
+                    }
+                }
+            }
+
+            if (_updateFromTextInput && !parsedTextIsValid)
+            {
+                if (_spinner is not null)
+                {
+                    _spinner.ValidSpinDirection = ValidSpinDirections.None;
+                }
+            }
+            else
+            {
+                SetValidSpinDirection();
+            }
+        }
+        finally
+        {
+            _isSyncingTextAndValue = false;
+        }
+        return parsedTextIsValid;
+    }
+
+    protected virtual T? ConvertTextToValue(string? text)
+    {
+        T? result;
+        if (string.IsNullOrWhiteSpace(text)) return null;
+        if (TextConverter != null)
+        {
+            var valueFromText = TextConverter.Convert(text, typeof(T?), null, CultureInfo.CurrentCulture);
+            return (T?)valueFromText;
+        }
+        else
+        {
+            if (!ParseText(text, out var outputValue))
+            {
+                throw new InvalidDataException("Input string was not in a correct format.");
+            }
+
+            result = outputValue;
+        }
+        return result;
+    }
+
+    protected virtual string? ConvertValueToText(T? value)
+    {
+        if (TextConverter is not null)
+        {
+            return TextConverter.ConvertBack(Value, typeof(int), null, CultureInfo.CurrentCulture)?.ToString();
+        }
+
+        if (FormatString.Contains("{0"))
+        {
+            return string.Format(NumberFormat, FormatString, value);
+        }
+
+        return ValueToString(Value);
+    }
+    
+    protected override void Increase()
+    {
+        T? value;
+        if (Value is not null)
+        {
+            value = Add(Value.Value, Step);
+        }
+        else
+        {
+            value = IsSet(MinimumProperty) ? Minimum : Zero;
+        }
+        SetCurrentValue(ValueProperty, Clamp(value, Maximum, Minimum));
+    }
+
+    protected override void Decrease()
+    {
+        T? value;
+        if (Value is not null)
+        {
+            value = Minus(Value.Value, Step);
+        }
+        else
+        {
+            value = IsSet(MaximumProperty) ? Maximum : Zero;
+        }
+
+        SetCurrentValue(ValueProperty, Clamp(value, Maximum, Minimum));
+    }
+    
+    protected abstract bool ParseText(string? text, out T? number);
+    protected abstract string? ValueToString(T? value);
+    protected abstract T Zero { get; }
+    protected abstract T? Add(T? a, T? b);
+    protected abstract T? Minus(T? a, T? b);
+
 }

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -108,15 +108,6 @@ public abstract class NumericUpDown : TemplatedControl
         set => SetValue(AllowSpinProperty, value);
     }
 
-    public static readonly StyledProperty<bool> AllowMouseWheelProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
-        nameof(AllowMouseWheel));
-
-    public bool AllowMouseWheel
-    {
-        get => GetValue(AllowMouseWheelProperty);
-        set => SetValue(AllowMouseWheelProperty, value);
-    }
-
     public event EventHandler<SpinEventArgs>? Spinned;
     
     static NumericUpDown()
@@ -223,7 +214,7 @@ public abstract class NumericUpDown : TemplatedControl
     
     private void OnDragPanelPointerMoved(object sender, PointerEventArgs e)
     {
-        if (!AllowDrag) return;
+        if (!AllowDrag || IsReadOnly) return;
         if(!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
         var point = e.GetPosition(this);
         var delta = point - _point;

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -449,11 +449,11 @@ public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComp
         }
         if (value.Value.CompareTo(max) > 0)
         {
-            return Maximum;
+            return max;
         }
         if (value.Value.CompareTo(min) < 0)
         {
-            return Minimum;
+            return min;
         }
         return value;
     }
@@ -520,7 +520,7 @@ public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComp
                     if (_textBox!= null && !Equals(_textBox.Text, newText))
                     {
                         _textBox.Text = newText;
-                        _textBox.CaretIndex = newText?.Length??0;
+                        _textBox.CaretIndex = newText?.Length ?? 0;
                     }
                 }
             }
@@ -609,7 +609,7 @@ public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComp
         SetCurrentValue(ValueProperty, Clamp(value, Maximum, Minimum));
     }
     
-    protected abstract bool ParseText(string? text, out T? number);
+    protected abstract bool ParseText(string? text, out T number);
     protected abstract string? ValueToString(T? value);
     protected abstract T Zero { get; }
     protected abstract T? Add(T? a, T? b);

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -27,13 +27,13 @@ public abstract class NumericUpDown : TemplatedControl
     private Point? _point;
     protected internal bool _updateFromTextInput;
     
-    public static readonly StyledProperty<bool> TextEditableProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
-        nameof(TextEditable), defaultValue: true);
+    public static readonly StyledProperty<bool> IsTextEditableProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
+        nameof(IsTextEditable), defaultValue: true);
 
-    public bool TextEditable
+    public bool IsTextEditable
     {
-        get => GetValue(TextEditableProperty);
-        set => SetValue(TextEditableProperty, value);
+        get => GetValue(IsTextEditableProperty);
+        set => SetValue(IsTextEditableProperty, value);
     }
 
     public static readonly StyledProperty<bool> IsReadOnlyProperty = AvaloniaProperty.Register<NumericUpDown, bool>(
@@ -207,7 +207,7 @@ public abstract class NumericUpDown : TemplatedControl
     
     private void OnDragPanelPointerMoved(object sender, PointerEventArgs e)
     {
-        if (TextEditable) return;
+        if (IsTextEditable) return;
         if(!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
         var point = e.GetPosition(this);
         var delta = point - _point;

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -230,7 +230,7 @@ public abstract class NumericUpDown : TemplatedControl
     private int GetDelta(Point point)
     {
         bool horizontal = Math.Abs(point.X) > Math.Abs(point.Y);
-        var value = horizontal ? point.X : point.Y;
+        var value = horizontal ? point.X : -point.Y;
         return value switch
         {
             > 0 => 1,

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -197,6 +197,7 @@ public abstract class NumericUpDown : TemplatedControl
     private void OnDragPanelPointerPressed(object sender, PointerPressedEventArgs e)
     {
         _point = e.GetPosition(this);
+        _textBox?.Focus();
     }
     
     private void OnDragPanelPointerReleased(object sender, PointerReleasedEventArgs e)
@@ -476,7 +477,6 @@ public abstract class NumericUpDownBase<T>: NumericUpDown where T: struct, IComp
             {
                 try
                 {
-                    // TODO
                     var newValue = ConvertTextToValue(text);
                     if (EmptyInputValue is not null && newValue is null)
                     {

--- a/src/Ursa/Controls/NumericUpDown/ValueChangedEventArgs.cs
+++ b/src/Ursa/Controls/NumericUpDown/ValueChangedEventArgs.cs
@@ -1,0 +1,15 @@
+using Avalonia.Interactivity;
+
+namespace Ursa.Controls;
+
+public class ValueChangedEventArgs<T>: RoutedEventArgs where T: struct, IComparable<T>
+{
+    public ValueChangedEventArgs(RoutedEvent routedEvent, T? oldValue, T? newValue): base(routedEvent)
+    {
+        OldValue = oldValue;
+        NewValue = newValue;
+    }
+    public T? OldValue { get; }
+    public T? NewValue { get; }
+    
+}


### PR DESCRIPTION
1. This bunch of controls utilize only one template but supports type safe control for every built in C# primitive number types. 
2. It supports Byte, SByte, Short, UShort, Int, UInt, Long, ULong, Float, Double, Decimal
3. Value is nullable but supports empty input fallback value.
4. When set `AllowDrag` = true, it supports dragging to change values. DoubleClick on textbox will enter edit mode, Esc or lost focus will exit edit mode. 