### PR TITLE
IPAddress DefaultBindingMode

### DIFF
--- a/src/Ursa/Controls/IPv4Box.cs
+++ b/src/Ursa/Controls/IPv4Box.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
+using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
@@ -43,7 +44,7 @@ public class IPv4Box: TemplatedControl
     private TextPresenter? _currentActivePresenter;
     
     public static readonly StyledProperty<IPAddress?> IPAddressProperty = AvaloniaProperty.Register<IPv4Box, IPAddress?>(
-        nameof(IPAddress));
+        nameof(IPAddress), defaultBindingMode: BindingMode.TwoWay);
     public IPAddress? IPAddress
     {
         get => GetValue(IPAddressProperty);


### PR DESCRIPTION
Another issue with `IPv4Box`:
``` cs
[ObservableProperty] private IPAddress? _address = IPAddress.Parse("192.168.1.1");

public void ChangeAddress()
{
    Address = IPAddress.Parse("192.168.0.1");
}
```

This `ChangeAddress` method will only take effect once.
For example, now it is  `192.168.1.1`.Then I press the button to change it, and this time it will change normally to `192.168.0.1`.But I'll make another change, such as changing it to  `1.1.1.1` Pressing the button will render it ineffective.
