### PR TITLE
Fix: Update ButtonGroup separator color for visibility in dark mode

### DIFF
--- a/src/Ursa.Themes.Semi/Themes/Dark/ButtonGroup.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Dark/ButtonGroup.axaml
@@ -1,5 +1,7 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <!--  Add Resources Here  -->
+    
+    <SolidColorBrush x:Key="ButtonGroupSeparatorForeground" Opacity="0.08" Color="White" />
     <!--  Light  -->
     <SolidColorBrush x:Key="ButtonGroupDefaultPrimaryForeground" Color="#54A9FF" />
     <SolidColorBrush x:Key="ButtonGroupDefaultSecondaryForeground" Color="#40B4F3" />


### PR DESCRIPTION
### Issue
Fixes #140

### Description
This PR addresses the issue where the ButtonGroup separator was invisible in dark mode by updating the ButtonGroupSeparatorForeground color to improve visibility. The opacity has been set to 0.08 with a white color to ensure the separator is visible in both light and dark modes.

### Changes Made
- Added SolidColorBrush with opacity 0.08 and color white for ButtonGroup separator
- Tested the changes in both light and dark modes to ensure improved visibility

### Additional Notes
- This fix should resolve the visibility issue in dark mode
- Please review and provide feedback