### PR TITLE
修复RangeSlider中，因鼠标移动速度过快而使Thumb无法重合的问题

### DIFF
--- a/src/Ursa/Controls/RangeSlider/RangeSlider.cs
+++ b/src/Ursa/Controls/RangeSlider/RangeSlider.cs
@@ -212,7 +212,7 @@ public class RangeSlider: TemplatedControl
     {
         if (_track is null) return;
         var value = GetValueByPoint(posOnTrack);
-        var thumb = GetThumbByPoint(posOnTrack);
+        var thumb = _isDragging ? _currentThumb : GetThumbByPoint(posOnTrack);
         if (_currentThumb !=null && _currentThumb != thumb) return;
         if (thumb is null) return;
         if (thumb == _track.LowerThumb)
@@ -221,6 +221,7 @@ public class RangeSlider: TemplatedControl
         }
         else
         {
+            if (LowerValue >= value) SetCurrentValue(LowerValueProperty, IsSnapToTick ? SnapToTick(value) : value);
             SetCurrentValue(UpperValueProperty, IsSnapToTick ? SnapToTick(value) : value);
         }
     }

--- a/src/Ursa/Controls/RangeSlider/RangeSlider.cs
+++ b/src/Ursa/Controls/RangeSlider/RangeSlider.cs
@@ -271,6 +271,7 @@ public class RangeSlider: TemplatedControl
         var isHorizontal = Orientation == Orientation.Horizontal;
         var lowerThumbPosition = isHorizontal? _track?.LowerThumb?.Bounds.Center.X : _track?.LowerThumb?.Bounds.Center.Y;
         var upperThumbPosition = isHorizontal? _track?.UpperThumb?.Bounds.Center.X : _track?.UpperThumb?.Bounds.Center.Y;
+        var mid = isHorizontal? _track?.Bounds.Center.X : _track?.Bounds.Center.Y;
         var pointerPosition = isHorizontal? point.Position.X : point.Position.Y;
 
         var lowerDistance = Math.Abs((lowerThumbPosition ?? 0) - pointerPosition);
@@ -280,10 +281,12 @@ public class RangeSlider: TemplatedControl
         {
             return _track?.LowerThumb;
         }
-        else
+        if(lowerDistance>upperDistance)
         {
             return _track?.UpperThumb;
         }
+        if (IsDirectionReversed) return pointerPosition < mid ? _track?.LowerThumb : _track?.UpperThumb;
+        return pointerPosition > mid ? _track?.LowerThumb : _track?.UpperThumb;
     }
     
     private double GetValueByPoint(PointerPoint point)

--- a/src/Ursa/Controls/RangeSlider/RangeSlider.cs
+++ b/src/Ursa/Controls/RangeSlider/RangeSlider.cs
@@ -217,11 +217,12 @@ public class RangeSlider: TemplatedControl
         if (thumb is null) return;
         if (thumb == _track.LowerThumb)
         {
+            if (UpperValue < value) SetCurrentValue(UpperValueProperty, IsSnapToTick ? SnapToTick(value) : value);
             SetCurrentValue(LowerValueProperty, IsSnapToTick ? SnapToTick(value) : value);
         }
         else
         {
-            if (LowerValue >= value) SetCurrentValue(LowerValueProperty, IsSnapToTick ? SnapToTick(value) : value);
+            if (LowerValue > value) SetCurrentValue(LowerValueProperty, IsSnapToTick ? SnapToTick(value) : value);
             SetCurrentValue(UpperValueProperty, IsSnapToTick ? SnapToTick(value) : value);
         }
     }


### PR DESCRIPTION
当拖拽时鼠标移动过快，使Thumb重合或无法接近。

以拖拽Upper Thumb为例
鼠标移动过快，会造成上一帧鼠标还在Upper thumb，而下一帧已经在Lower thumb左侧，使Line 216 中的``` _currentThumb != thumb```提前触发而return掉。

所以加了一个判断，如果是在拖拽状态，让thumb 等于 _currentThumb，这样就可以确保拖拽中途不会发生``` _currentThumb != thumb```的情况。

但这样会产生一个Bug，当拖拽Lower thumb使其与Upper thumb在slider最右侧重合时，因为Upper thumb的图层在Lower thumb之上，会导致无法调节的情况。而且也会出现Lower value大于Upper value或Upper value 小于 Lower value的情况。

我的解决办法：
SetCurrentValue时，顺带检查是否存在Lower value大于Upper value或Upper value 小于 Lower value的情况，然后将Lower value（或Upper value）修正。