### PR TITLE
TagInput 增加 CleanLostFocus 用于失去焦点后清空TextBox数据

### DIFF
--- a/demo/Ursa.Demo/Pages/TagInputDemo.axaml
+++ b/demo/Ursa.Demo/Pages/TagInputDemo.axaml
@@ -21,6 +21,7 @@
         <u:TagInput
             Margin="20"
             AllowDuplicates="False"
+            CleanLostFocus="true"
             Separator="-"
             Tags="{Binding DistinctTags}" />
         <ListBox ItemsSource="{Binding DistinctTags}" />

--- a/demo/Ursa.Demo/Pages/TagInputDemo.axaml
+++ b/demo/Ursa.Demo/Pages/TagInputDemo.axaml
@@ -21,7 +21,7 @@
         <u:TagInput
             Margin="20"
             AllowDuplicates="False"
-            CleanLostFocus="true"
+            LostFocusBehavior="Clear"
             Separator="-"
             Tags="{Binding DistinctTags}" />
         <ListBox ItemsSource="{Binding DistinctTags}" />

--- a/src/Ursa/Controls/TagInput/LostFocusBehavior.cs
+++ b/src/Ursa/Controls/TagInput/LostFocusBehavior.cs
@@ -1,0 +1,8 @@
+﻿namespace Ursa.Controls;
+
+public enum LostFocusBehavior
+{
+    None,
+    Add,
+    Clear,
+}

--- a/src/Ursa/Controls/TagInput/TagInput.cs
+++ b/src/Ursa/Controls/TagInput/TagInput.cs
@@ -60,9 +60,14 @@ public class TagInput : TemplatedControl
 
     private void OnTextBox_LostFocus(object? sender, RoutedEventArgs e)
     {
-        if(CleanLostFocus)
+        switch (LostFocusBehavior)
         {
-            _textBox.Text = "";
+            case LostFocusBehavior.Add:
+                AddTags();
+                break;
+            case LostFocusBehavior.Clear:
+                _textBox.Text = "";
+                break;
         }
     }
 
@@ -95,13 +100,13 @@ public class TagInput : TemplatedControl
         set => SetValue(SeparatorProperty, value);
     }
 
-    public static readonly StyledProperty<bool> CleanLostFocusProperty = AvaloniaProperty.Register<TagInput, bool>(
-        nameof(CleanLostFocus), defaultValue: false);
+    public static readonly StyledProperty<LostFocusBehavior> LostFocusBehaviorProperty = AvaloniaProperty.Register<TagInput, LostFocusBehavior>(
+        nameof(LostFocusBehavior));
 
-    public bool CleanLostFocus
+    public LostFocusBehavior LostFocusBehavior
     {
-        get => GetValue(CleanLostFocusProperty);
-        set => SetValue(CleanLostFocusProperty, value);
+        get => GetValue(LostFocusBehaviorProperty);
+        set => SetValue(LostFocusBehaviorProperty, value);
     }
 
 
@@ -222,31 +227,7 @@ public class TagInput : TemplatedControl
     {
         if (args.Key == Key.Enter)
         {
-            if (_textBox.Text?.Length > 0)
-            {
-                string[] values;
-                if (!string.IsNullOrEmpty(Separator))
-                {
-                    values = _textBox.Text.Split(new string[] { Separator },
-                        StringSplitOptions.RemoveEmptyEntries);
-                }
-                else
-                {
-                    values = new[] { _textBox.Text };
-                }
-
-                if (!AllowDuplicates && Tags != null)
-                    values = values.Distinct().Except(Tags).ToArray();
-
-                for (int i = 0; i < values.Length; i++)
-                {
-                    int index = Items.Count - 1;
-                    // Items.Insert(index, values[i]);
-                    Tags?.Insert(index, values[i]);
-                }
-
-                _textBox.Text = "";
-            }
+            AddTags();
         }
         else if (args.Key == Key.Delete || args.Key == Key.Back)
         { 
@@ -261,6 +242,33 @@ public class TagInput : TemplatedControl
                 Tags.RemoveAt(index);
             }
         }
+    }
+    
+    private void AddTags()
+    {
+        if (!(_textBox.Text?.Length > 0)) return;
+        string[] values;
+        if (!string.IsNullOrEmpty(Separator))
+        {
+            values = _textBox.Text.Split(new string[] { Separator },
+                StringSplitOptions.RemoveEmptyEntries);
+        }
+        else
+        {
+            values = new[] { _textBox.Text };
+        }
+
+        if (!AllowDuplicates && Tags != null)
+            values = values.Distinct().Except(Tags).ToArray();
+
+        for (int i = 0; i < values.Length; i++)
+        {
+            int index = Items.Count - 1;
+            // Items.Insert(index, values[i]);
+            Tags?.Insert(index, values[i]);
+        }
+
+        _textBox.Text = "";
     }
 
     public void Close(object o)

--- a/src/Ursa/Controls/TagInput/TagInput.cs
+++ b/src/Ursa/Controls/TagInput/TagInput.cs
@@ -50,11 +50,20 @@ public class TagInput : TemplatedControl
     {
         _textBox = new TextBox();
         _textBox.AddHandler(KeyDownEvent, OnTextBoxKeyDown, RoutingStrategies.Tunnel);
+        _textBox.AddHandler(LostFocusEvent, OnTextBox_LostFocus, RoutingStrategies.Bubble);
         Items = new AvaloniaList<object>
         {
             _textBox
         };
         Tags = new ObservableCollection<string>();
+    }
+
+    private void OnTextBox_LostFocus(object? sender, RoutedEventArgs e)
+    {
+        if(CleanLostFocus)
+        {
+            _textBox.Text = "";
+        }
     }
 
     public static readonly StyledProperty<ControlTheme> InputThemeProperty =
@@ -85,6 +94,16 @@ public class TagInput : TemplatedControl
         get => GetValue(SeparatorProperty);
         set => SetValue(SeparatorProperty, value);
     }
+
+    public static readonly StyledProperty<bool> CleanLostFocusProperty = AvaloniaProperty.Register<TagInput, bool>(
+        nameof(CleanLostFocus), defaultValue: false);
+
+    public bool CleanLostFocus
+    {
+        get => GetValue(CleanLostFocusProperty);
+        set => SetValue(CleanLostFocusProperty, value);
+    }
+
 
     public static readonly StyledProperty<bool> AllowDuplicatesProperty = AvaloniaProperty.Register<TagInput, bool>(
         nameof(AllowDuplicates), defaultValue: true);


### PR DESCRIPTION
https://github.com/irihitech/Ursa.Avalonia/assets/3275834/51715d50-9d2c-47a3-b4d9-3626807bceb7

当用户输入数据后未删除也没有回车使数据生效时，需要提供一个方式可以清理未生效的数据