### PR TITLE
fix TagInput bug when TagsProperty changed.

### DIFF
--- a/src/Ursa/Controls/TagInput/TagInput.cs
+++ b/src/Ursa/Controls/TagInput/TagInput.cs
@@ -165,10 +165,14 @@ public class TagInput : TemplatedControl
     {
         var newTags = args.GetNewValue<IList<string>>();
         var oldTags = args.GetOldValue<IList<string>>();
-        for (int i = 0; i < Items.Count - 1; i++)
+        
+        // remove all tags except the textbox
+        int count = Items.Count;
+        for (int i = 0; i < count - 1; i++)
         {
-            Items.RemoveAt(Items.Count - 1);
+            Items.RemoveAt(0);
         }
+        
         if (newTags != null)
         {
             for (int i = 0; i < newTags.Count; i++)

--- a/src/Ursa/Controls/TagInput/TagInput.cs
+++ b/src/Ursa/Controls/TagInput/TagInput.cs
@@ -166,11 +166,14 @@ public class TagInput : TemplatedControl
         var newTags = args.GetNewValue<IList<string>>();
         var oldTags = args.GetOldValue<IList<string>>();
         
-        // remove all tags except the textbox
-        int count = Items.Count;
-        for (int i = 0; i < count - 1; i++)
+        if (Items is AvaloniaList<object> avaloniaList)
         {
-            Items.RemoveAt(0);
+            avaloniaList.RemoveRange(0, avaloniaList.Count - 1);
+        }
+        else if (Items.Count != 0)
+        {
+            Items.Clear();
+            Items.Add(_textBox);
         }
         
         if (newTags != null)


### PR DESCRIPTION
When TagInput's Tags changed, you want remove all the tags except the textBox from `Items` collection, right? But the code does not do that.

old code:
```cs
 for (int i = 0; i < Items.Count - 1; i++)
 {
     Items.RemoveAt(Items.Count - 1);
 }
```
Items.Count will change after every `RemoveAt` so If the `Items.Count` is 6, It only remove 3 times, then `i` will be 3,`Items.Count` will be 3, the loop will end.

So, I fix this problem.
new code:
```cs
// remove all tags except the textbox
int count = Items.Count;
for (int i = 0; i < count - 1; i++)
{
    Items.RemoveAt(0);
}
```

I create a repro branch(https://github.com/dameng324/Ursa.Avalonia/tree/taginput-fix-tags-changed-repo) to repro this problem. Feel free to check it.


