### PR TITLE
OverlayDiaogHost refatoring

### DIFF
--- a/demo/Ursa.Demo/Views/MainView.axaml
+++ b/demo/Ursa.Demo/Views/MainView.axaml
@@ -20,7 +20,13 @@
         <converters:IconNameToPathConverter x:Key="IconConverter" />
     </UserControl.Resources>
     <Panel>
+        <Panel.Styles>
+            <Style Selector="Grid.Blur">
+                <Setter Property="Effect" Value="blur(10)"></Setter>
+            </Style>
+        </Panel.Styles>
         <Grid
+            Classes.Blur="{Binding $parent[u:UrsaWindow].(u:OverlayDialogHost.IsInModalStatus)}"
             ColumnDefinitions="Auto, *" >
             <Border
                 Padding="8 4"

--- a/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
@@ -11,6 +11,7 @@
         <Setter Property="FontFamily" Value="{DynamicResource DefaultFontFamily}" />
         <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="-1" />
         <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
+        <Setter Property="u:OverlayDialogHost.IsModalStatusScope" Value="True"/>
         <Setter Property="SystemDecorations">
             <OnPlatform>
                 <OnPlatform.Default>

--- a/src/Ursa/Controls/Dialog/Options/OverlayDialogOptions.cs
+++ b/src/Ursa/Controls/Dialog/Options/OverlayDialogOptions.cs
@@ -46,4 +46,8 @@ public class OverlayDialogOptions
     public bool ShowCloseButton { get; set; } = true;
     public bool CanLightDismiss { get; set; }
     public bool CanDragMove { get; set; } = true;
+    /// <summary>
+    /// The hash code of the top level dialog host. This is used to identify the dialog host if there are multiple dialog hosts with the same id. If this is not provided, the dialog will be added to the first dialog host with the same id.
+    /// </summary>
+    public int? TopLevelHashCode { get; set; }
 }

--- a/src/Ursa/Controls/Dialog/OverlayDialog.cs
+++ b/src/Ursa/Controls/Dialog/OverlayDialog.cs
@@ -11,7 +11,7 @@ public static class OverlayDialog
         OverlayDialogOptions? options = null)
         where TView : Control, new()
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
         var t = new DefaultDialogControl()
         {
@@ -25,7 +25,7 @@ public static class OverlayDialog
     public static void Show(Control control, object? vm, string? hostId = null,
         OverlayDialogOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
         var t = new DefaultDialogControl()
         {
@@ -39,7 +39,7 @@ public static class OverlayDialog
     
     public static void Show(object? vm, string? hostId = null, OverlayDialogOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
         var view = host.GetDataTemplate(vm)?.Build(vm);
         if (view is null) view = new ContentControl();
@@ -57,7 +57,7 @@ public static class OverlayDialog
         OverlayDialogOptions? options = null)
         where TView: Control, new()
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
         var t = new CustomDialogControl()
         {
@@ -71,7 +71,7 @@ public static class OverlayDialog
     public static void ShowCustom(Control control, object? vm, string? hostId = null,
         OverlayDialogOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
         var t = new CustomDialogControl()
         {
@@ -85,7 +85,7 @@ public static class OverlayDialog
     public static void ShowCustom(object? vm, string? hostId = null,
         OverlayDialogOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
         var view = host.GetDataTemplate(vm)?.Build(vm);
         if (view is null) view = new ContentControl() { Padding = new Thickness(24) };
@@ -103,7 +103,7 @@ public static class OverlayDialog
         OverlayDialogOptions? options = null, CancellationToken? token = default)
         where TView: Control, new()
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult(DialogResult.None);
         var t = new DefaultDialogControl()
         {
@@ -118,7 +118,7 @@ public static class OverlayDialog
     public static Task<DialogResult> ShowModal(Control control, object? vm, string? hostId = null,
         OverlayDialogOptions? options = null, CancellationToken? token = default)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult(DialogResult.None);
         var t = new DefaultDialogControl()
         {
@@ -134,7 +134,7 @@ public static class OverlayDialog
         OverlayDialogOptions? options = null, CancellationToken? token = default)
         where TView: Control, new()
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult(default(TResult));
         var t = new CustomDialogControl()
         {
@@ -149,7 +149,7 @@ public static class OverlayDialog
     public static Task<TResult?> ShowCustomModal<TResult>(Control control, object? vm, string? hostId = null,
         OverlayDialogOptions? options = null, CancellationToken? token = default)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult(default(TResult));
         var t = new CustomDialogControl()
         {
@@ -164,7 +164,7 @@ public static class OverlayDialog
     public static Task<TResult?> ShowCustomModal<TResult>(object? vm, string? hostId = null,
         OverlayDialogOptions? options = null, CancellationToken? token = default)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult(default(TResult));
         var view = host.GetDataTemplate(vm)?.Build(vm);
         if (view is null) view = new ContentControl() { Padding = new Thickness(24) };
@@ -227,7 +227,7 @@ public static class OverlayDialog
 
     internal static T? Recall<T>(string? hostId) where T: Control
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, null);
         if (host is null) return null;
         var item = host.Recall<T>();
         return item;

--- a/src/Ursa/Controls/Drawer/Drawer.cs
+++ b/src/Ursa/Controls/Drawer/Drawer.cs
@@ -8,14 +8,14 @@ namespace Ursa.Controls;
 public static class Drawer
 {
     public static void Show<TView, TViewModel>(TViewModel vm, string? hostId = null, DrawerOptions? options = null)
-        where TView: Control, new()
+        where TView : Control, new()
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
-        var drawer = new DefaultDrawerControl()
+        var drawer = new DefaultDrawerControl
         {
             Content = new TView(),
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureDefaultDrawer(drawer, options);
         host.AddDrawer(drawer);
@@ -24,12 +24,12 @@ public static class Drawer
     public static void Show(Control control, object? vm, string? hostId = null,
         DrawerOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
-        var drawer = new DefaultDrawerControl()
+        var drawer = new DefaultDrawerControl
         {
             Content = control,
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureDefaultDrawer(drawer, options);
         host.AddDrawer(drawer);
@@ -37,29 +37,30 @@ public static class Drawer
 
     public static void Show(object? vm, string? hostId = null, DrawerOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
         var view = host.GetDataTemplate(vm)?.Build(vm);
-        if (view is null) view = new ContentControl() { Padding = new Thickness(24) };
+        if (view is null) view = new ContentControl { Padding = new Thickness(24) };
         view.DataContext = vm;
-        var drawer = new DefaultDrawerControl()
+        var drawer = new DefaultDrawerControl
         {
             Content = view,
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureDefaultDrawer(drawer, options);
         host.AddDrawer(drawer);
     }
-    
-    public static Task<DialogResult> ShowModal<TView, TViewModel>(TViewModel vm, string? hostId = null, DrawerOptions? options = null)
-        where TView: Control, new()
+
+    public static Task<DialogResult> ShowModal<TView, TViewModel>(TViewModel vm, string? hostId = null,
+        DrawerOptions? options = null)
+        where TView : Control, new()
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult(DialogResult.None);
-        var drawer = new DefaultDrawerControl()
+        var drawer = new DefaultDrawerControl
         {
             Content = new TView(),
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureDefaultDrawer(drawer, options);
         host.AddModalDrawer(drawer);
@@ -69,12 +70,12 @@ public static class Drawer
     public static Task<DialogResult> ShowModal(Control control, object? vm, string? hostId = null,
         DrawerOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult(DialogResult.None);
-        var drawer = new DefaultDrawerControl()
+        var drawer = new DefaultDrawerControl
         {
             Content = control,
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureDefaultDrawer(drawer, options);
         host.AddModalDrawer(drawer);
@@ -83,110 +84,114 @@ public static class Drawer
 
     public static Task<DialogResult> ShowModal(object? vm, string? hostId = null, DrawerOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult(DialogResult.None);
         var view = host.GetDataTemplate(vm)?.Build(vm);
-        if (view is null) view = new ContentControl() { Padding = new Thickness(24) };
+        if (view is null) view = new ContentControl { Padding = new Thickness(24) };
         view.DataContext = vm;
-        var drawer = new DefaultDrawerControl()
+        var drawer = new DefaultDrawerControl
         {
             Content = view,
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureDefaultDrawer(drawer, options);
         host.AddModalDrawer(drawer);
         return drawer.ShowAsync<DialogResult>();
     }
-    
-    public static void ShowCustom<TView, TViewModel>(TViewModel vm, string? hostId = null, DrawerOptions? options = null)
-        where TView: Control, new()
+
+    public static void ShowCustom<TView, TViewModel>(TViewModel vm, string? hostId = null,
+        DrawerOptions? options = null)
+        where TView : Control, new()
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
-        var dialog = new CustomDrawerControl()
+        var dialog = new CustomDrawerControl
         {
             Content = new TView(),
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureCustomDrawer(dialog, options);
         host.AddDrawer(dialog);
     }
-    
+
     public static void ShowCustom(Control control, object? vm, string? hostId = null, DrawerOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
-        var dialog = new CustomDrawerControl()
+        var dialog = new CustomDrawerControl
         {
             Content = control,
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureCustomDrawer(dialog, options);
         host.AddDrawer(dialog);
     }
-    
+
     public static void ShowCustom(object? vm, string? hostId = null, DrawerOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return;
         var view = host.GetDataTemplate(vm)?.Build(vm);
-        if (view is null) view = new ContentControl() { Padding = new Thickness(24) };
+        if (view is null) view = new ContentControl { Padding = new Thickness(24) };
         view.DataContext = vm;
-        var dialog = new CustomDrawerControl()
+        var dialog = new CustomDrawerControl
         {
             Content = view,
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureCustomDrawer(dialog, options);
         host.AddDrawer(dialog);
     }
-    
-    public static Task<TResult?> ShowCustomModal<TView, TViewModel, TResult>(TViewModel vm, string? hostId = null, DrawerOptions? options = null)
-        where TView: Control, new()
+
+    public static Task<TResult?> ShowCustomModal<TView, TViewModel, TResult>(TViewModel vm, string? hostId = null,
+        DrawerOptions? options = null)
+        where TView : Control, new()
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult<TResult?>(default);
-        var dialog = new CustomDrawerControl()
+        var dialog = new CustomDrawerControl
         {
             Content = new TView(),
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureCustomDrawer(dialog, options);
         host.AddModalDrawer(dialog);
         return dialog.ShowAsync<TResult?>();
     }
-    
-    public static Task<TResult?> ShowCustomModal<TResult>(Control control, object? vm, string? hostId = null, DrawerOptions? options = null)
+
+    public static Task<TResult?> ShowCustomModal<TResult>(Control control, object? vm, string? hostId = null,
+        DrawerOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult<TResult?>(default);
-        var dialog = new CustomDrawerControl()
+        var dialog = new CustomDrawerControl
         {
             Content = control,
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureCustomDrawer(dialog, options);
         host.AddModalDrawer(dialog);
         return dialog.ShowAsync<TResult?>();
     }
-    
-    public static Task<TResult?> ShowCustomModal<TResult>(object? vm, string? hostId = null, DrawerOptions? options = null)
+
+    public static Task<TResult?> ShowCustomModal<TResult>(object? vm, string? hostId = null,
+        DrawerOptions? options = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);
         if (host is null) return Task.FromResult<TResult?>(default);
         var view = host.GetDataTemplate(vm)?.Build(vm);
-        if (view is null) view = new ContentControl() { Padding = new Thickness(24) };
+        if (view is null) view = new ContentControl { Padding = new Thickness(24) };
         view.DataContext = vm;
-        var dialog = new CustomDrawerControl()
+        var dialog = new CustomDrawerControl
         {
             Content = view,
-            DataContext = vm,
+            DataContext = vm
         };
         ConfigureCustomDrawer(dialog, options);
         host.AddModalDrawer(dialog);
         return dialog.ShowAsync<TResult?>();
     }
-    
+
     private static void ConfigureCustomDrawer(CustomDrawerControl drawer, DrawerOptions? options)
     {
         options ??= DrawerOptions.Default;
@@ -198,13 +203,14 @@ public static class Drawer
             drawer.MinWidth = options.MinWidth ?? 0.0;
             drawer.MaxWidth = options.MaxWidth ?? double.PositiveInfinity;
         }
+
         if (options.Position is Position.Top or Position.Bottom)
         {
             drawer.MinHeight = options.MinHeight ?? 0.0;
             drawer.MaxHeight = options.MaxHeight ?? double.PositiveInfinity;
         }
     }
-    
+
     private static void ConfigureDefaultDrawer(DefaultDrawerControl drawer, DrawerOptions? options)
     {
         options ??= DrawerOptions.Default;
@@ -218,6 +224,7 @@ public static class Drawer
             drawer.MinWidth = options.MinWidth ?? 0.0;
             drawer.MaxWidth = options.MaxWidth ?? double.PositiveInfinity;
         }
+
         if (options.Position is Position.Top or Position.Bottom)
         {
             drawer.MinHeight = options.MinHeight ?? 0.0;

--- a/src/Ursa/Controls/Drawer/Options/DrawerOptions.cs
+++ b/src/Ursa/Controls/Drawer/Options/DrawerOptions.cs
@@ -15,4 +15,8 @@ public class DrawerOptions
     public DialogButton Buttons { get; set; } = DialogButton.OKCancel;
     public string? Title { get; set; }
     public bool ShowCloseButton { get; set; } = true;
+    /// <summary>
+    /// The hash code of the top level dialog host. This is used to identify the dialog host if there are multiple dialog hosts with the same id. If this is not provided, the dialog will be added to the first dialog host with the same id.
+    /// </summary>
+    public int? TopLevelHashCode { get; set; }
 }

--- a/src/Ursa/Controls/MessageBox/MessageBox.cs
+++ b/src/Ursa/Controls/MessageBox/MessageBox.cs
@@ -1,15 +1,13 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Controls.Notifications;
-using Avalonia.Styling;
 
 namespace Ursa.Controls;
 
 public static class MessageBox
 {
     public static async Task<MessageBoxResult> ShowAsync(
-        string message, 
+        string message,
         string? title = null,
         MessageBoxIcon icon = MessageBoxIcon.None,
         MessageBoxButton button = MessageBoxButton.OKCancel)
@@ -18,33 +16,25 @@ public static class MessageBox
         {
             Content = message,
             Title = title,
-            MessageIcon = icon,
+            MessageIcon = icon
         };
         var lifetime = Application.Current?.ApplicationLifetime;
-        if (lifetime is IClassicDesktopStyleApplicationLifetime classLifetime)
+        if (lifetime is not IClassicDesktopStyleApplicationLifetime classLifetime) return MessageBoxResult.None;
+        var main = classLifetime.MainWindow;
+        if (main is null)
         {
-            var main = classLifetime.MainWindow;
-            if (main is null)
-            {
-                messageWindow.Show();
-                return MessageBoxResult.None;
-            }
-            else
-            {
-                var result = await messageWindow.ShowDialog<MessageBoxResult>(main);
-                return result;
-            }
-        }
-        else
-        {
+            messageWindow.Show();
             return MessageBoxResult.None;
         }
+
+        var result = await messageWindow.ShowDialog<MessageBoxResult>(main);
+        return result;
     }
-    
+
     public static async Task<MessageBoxResult> ShowAsync(
         Window owner,
-        string message, 
-        string title, 
+        string message,
+        string title,
         MessageBoxIcon icon = MessageBoxIcon.None,
         MessageBoxButton button = MessageBoxButton.OKCancel)
     {
@@ -52,7 +42,7 @@ public static class MessageBox
         {
             Content = message,
             Title = title,
-            MessageIcon = icon,
+            MessageIcon = icon
         };
         var result = await messageWindow.ShowDialog<MessageBoxResult>(owner);
         return result;
@@ -63,16 +53,17 @@ public static class MessageBox
         string? title = null,
         string? hostId = null,
         MessageBoxIcon icon = MessageBoxIcon.None,
-        MessageBoxButton button = MessageBoxButton.OKCancel)
+        MessageBoxButton button = MessageBoxButton.OKCancel,
+        int? toplevelHashCode = null)
     {
-        var host = OverlayDialogManager.GetHost(hostId);
+        var host = OverlayDialogManager.GetHost(hostId, toplevelHashCode);
         if (host is null) return MessageBoxResult.None;
-        var messageControl = new MessageBoxControl()
+        var messageControl = new MessageBoxControl
         {
             Content = message,
             Title = title,
             Buttons = button,
-            MessageIcon = icon,
+            MessageIcon = icon
         };
         host.AddModalDialog(messageControl);
         var result = await messageControl.ShowAsync<MessageBoxResult>();

--- a/src/Ursa/Controls/OverlayShared/OverlayDialogHost.Dialog.cs
+++ b/src/Ursa/Controls/OverlayShared/OverlayDialogHost.Dialog.cs
@@ -129,7 +129,7 @@ public partial class OverlayDialogHost
                 if (layer.Modal)
                 {
                     _modalCount--;
-                    HasModal = _modalCount > 0;
+                    IsInModalStatus = _modalCount > 0;
                     if (!IsAnimationDisabled)
                     {
                         await _maskDisappearAnimation.RunAsync(layer.Mask);
@@ -170,7 +170,7 @@ public partial class OverlayDialogHost
             _maskAppearAnimation.RunAsync(mask);
         }
         _modalCount++;
-        HasModal = _modalCount > 0;
+        IsInModalStatus = _modalCount > 0;
         control.IsClosed = false;
     }
 

--- a/src/Ursa/Controls/OverlayShared/OverlayDialogHost.Drawer.cs
+++ b/src/Ursa/Controls/OverlayShared/OverlayDialogHost.Drawer.cs
@@ -56,7 +56,7 @@ public partial class OverlayDialogHost
         control.Arrange(new Rect(control.DesiredSize));
         SetDrawerPosition(control);
         _modalCount++;
-        HasModal = _modalCount > 0;
+        IsInModalStatus = _modalCount > 0;
         control.AddHandler(OverlayFeedbackElement.ClosedEvent, OnDrawerControlClosing);
         var animation = CreateAnimation(control.Bounds.Size, control.Position);
         if (IsAnimationDisabled)
@@ -162,7 +162,7 @@ public partial class OverlayDialogHost
             if (layer.Mask is not null)
             {
                 _modalCount--;
-                HasModal = _modalCount > 0;
+                IsInModalStatus = _modalCount > 0;
                 layer.Mask.RemoveHandler(PointerPressedEvent, ClickMaskToCloseDialog);
                 if (!IsAnimationDisabled)
                 {


### PR DESCRIPTION
1. Support register host with same ID as long as they are in different toplevels. 
2. Add TopLevelHashCode to overlay related options, allow user to assign a toplevle hash code. 
3. Obsolete `HasModal` attribute, replace by `IsInModalStatus`.
4. Allow to set any control as ModalStatusScope.
5. Support propagating IsInModalStatus to visual ancestor that is ModalStatusScope. 

Closes:
Closes #281 
Closes #282 