### PR TITLE
feat: MultiComboBox may support placeholder (watermark)

### DIFF
--- a/demo/Ursa.Demo/Pages/MultiComboBoxDemo.axaml
+++ b/demo/Ursa.Demo/Pages/MultiComboBoxDemo.axaml
@@ -14,7 +14,7 @@
     <StackPanel Orientation="Horizontal">
         <u:MultiComboBox
             Name="combo"
-            PlaceholderText="Please Select"
+            Watermark="Please Select"
             InnerLeftContent="Left"
             InnerRightContent="Right"
             Classes="ClearButton"

--- a/demo/Ursa.Demo/Pages/MultiComboBoxDemo.axaml
+++ b/demo/Ursa.Demo/Pages/MultiComboBoxDemo.axaml
@@ -14,6 +14,7 @@
     <StackPanel Orientation="Horizontal">
         <u:MultiComboBox
             Name="combo"
+            PlaceholderText="Please Select"
             InnerLeftContent="Left"
             InnerRightContent="Right"
             Classes="ClearButton"

--- a/src/Ursa.Themes.Semi/Controls/MultiComboBox.axaml
+++ b/src/Ursa.Themes.Semi/Controls/MultiComboBox.axaml
@@ -53,7 +53,7 @@
                                   Foreground="{TemplateBinding Foreground}"
                                   IsVisible="False"
                                   Opacity="0.3"
-                                  Text="{TemplateBinding PlaceholderText}" />
+                                  Text="{TemplateBinding Watermark}" />
                                 <ScrollViewer
                                     Grid.Column="1"
                                     Grid.ColumnSpan="2"

--- a/src/Ursa.Themes.Semi/Controls/MultiComboBox.axaml
+++ b/src/Ursa.Themes.Semi/Controls/MultiComboBox.axaml
@@ -42,6 +42,18 @@
                                     Foreground="{DynamicResource TextBoxInnerForeground}"
                                     IsVisible="{TemplateBinding InnerLeftContent,
                                                                 Converter={x:Static ObjectConverters.IsNotNull}}" />
+                                <TextBlock
+                                  x:Name="PlaceholderTextBlock"
+                                  Grid.Column="1"
+                                  Grid.ColumnSpan="2"
+                                  Margin="{TemplateBinding Padding}"
+                                  TextTrimming="CharacterEllipsis"
+                                  HorizontalAlignment="Left"
+                                  VerticalAlignment="Center"
+                                  Foreground="{TemplateBinding Foreground}"
+                                  IsVisible="False"
+                                  Opacity="0.3"
+                                  Text="{TemplateBinding PlaceholderText}" />
                                 <ScrollViewer
                                     Grid.Column="1"
                                     Grid.ColumnSpan="2"
@@ -135,6 +147,9 @@
             </Style>
         </Style>
 
+        <Style Selector="^:selection-empty /template/ TextBlock#PlaceholderTextBlock">
+            <Setter Property="IsVisible" Value="{Binding $parent[ComboBox].SelectionBoxItem, Converter={x:Static ObjectConverters.IsNotNull}}" />
+        </Style>
 
         <!--  Pointerover State  -->
         <Style Selector="^:pointerover">

--- a/src/Ursa/Controls/ComboBox/MultiComboBox.cs
+++ b/src/Ursa/Controls/ComboBox/MultiComboBox.cs
@@ -88,13 +88,13 @@ public class MultiComboBox: SelectingItemsControl, IInnerContentControl
         set => SetValue(SelectedItemTemplateProperty, value);
     }
 
-    public static readonly StyledProperty<string?> PlaceholderTextProperty =
-        ComboBox.PlaceholderTextProperty.AddOwner<MultiComboBox>();
+    public static readonly StyledProperty<string?> WatermarkProperty =
+        TextBox.WatermarkProperty.AddOwner<MultiComboBox>();
 
-    public string? PlaceholderText
+    public string? Watermark
     {
-        get => GetValue(PlaceholderTextProperty);
-        set => SetValue(PlaceholderTextProperty, value);
+        get => GetValue(WatermarkProperty);
+        set => SetValue(WatermarkProperty, value);
     }
 
     static MultiComboBox()

--- a/src/Ursa/Controls/ComboBox/MultiComboBox.cs
+++ b/src/Ursa/Controls/ComboBox/MultiComboBox.cs
@@ -87,7 +87,16 @@ public class MultiComboBox: SelectingItemsControl, IInnerContentControl
         get => GetValue(SelectedItemTemplateProperty);
         set => SetValue(SelectedItemTemplateProperty, value);
     }
-    
+
+    public static readonly StyledProperty<string?> PlaceholderTextProperty =
+        ComboBox.PlaceholderTextProperty.AddOwner<MultiComboBox>();
+
+    public string? PlaceholderText
+    {
+        get => GetValue(PlaceholderTextProperty);
+        set => SetValue(PlaceholderTextProperty, value);
+    }
+
     static MultiComboBox()
     {
         FocusableProperty.OverrideDefaultValue<MultiComboBox>(true);


### PR DESCRIPTION
~~This PR attempts to add support for a placeholder similar to `ComboBox` for `MultiComboBox`.~~

~~The control theme of `ComboBox` in Semi.Avalonia does not respect the `PlaceholderForeground` property, so this PR also does not add the `PlaceholderForeground` property for the `MultiComboBox`.~~

Newly added property is renamed to `Watermark`. Details can be found below.

---

## Preview

![image](https://github.com/user-attachments/assets/19827e18-08c0-49b7-b6e3-af78c23842e6)
![image](https://github.com/user-attachments/assets/c082c2d4-1e68-4fec-95bd-001c76a8c089)

![image](https://github.com/user-attachments/assets/0bf0a8a2-2e3f-4639-8d36-4ec65aed3226)
![image](https://github.com/user-attachments/assets/b803363e-22c2-4605-8e8c-4eeb487114a9)

---

## API Changes

```diff
+ MultiComboBox.WatermarkProperty
+ MultiComboBox.Watermark
```

No breaking changes will be introduced.
