### PR TITLE
feat: Breadcrumb and its item may support CommandParameter/Binding

### DIFF
--- a/src/Ursa/Controls/Breadcrumb/Breadcrumb.cs
+++ b/src/Ursa/Controls/Breadcrumb/Breadcrumb.cs
@@ -35,6 +35,17 @@ public class Breadcrumb: ItemsControl
         set => SetValue(CommandBindingProperty, value);
     }
 
+    public static readonly StyledProperty<IBinding?> CommandParameterBindingProperty = AvaloniaProperty.Register<Breadcrumb, IBinding?>(
+        nameof(CommandParameterBinding));
+
+    [AssignBinding]
+    [InheritDataTypeFromItems(nameof(ItemsSource))]
+    public IBinding? CommandParameterBinding
+    {
+        get => GetValue(CommandParameterBindingProperty);
+        set => SetValue(CommandParameterBindingProperty, value);
+    }
+
     public static readonly StyledProperty<object?> SeparatorProperty = AvaloniaProperty.Register<Breadcrumb, object?>(
         nameof(Separator));
 
@@ -111,6 +122,10 @@ public class Breadcrumb: ItemsControl
         if (!breadcrumbItem.IsSet(BreadcrumbItem.CommandProperty) && CommandBinding != null)
         {
             breadcrumbItem[!BreadcrumbItem.CommandProperty] = CommandBinding;
+        }
+        if (!breadcrumbItem.IsSet(BreadcrumbItem.CommandParameterProperty) && CommandParameterBinding != null)
+        {
+            breadcrumbItem[!BreadcrumbItem.CommandParameterProperty] = CommandParameterBinding;
         }
         if (!breadcrumbItem.IsSet(BreadcrumbItem.IconTemplateProperty) && IconTemplate != null)
         {

--- a/src/Ursa/Controls/Breadcrumb/BreadcrumbItem.cs
+++ b/src/Ursa/Controls/Breadcrumb/BreadcrumbItem.cs
@@ -39,6 +39,15 @@ public class BreadcrumbItem: ContentControl
         set => SetValue(CommandProperty, value);
     }
 
+    public static readonly StyledProperty<object?> CommandParameterProperty = AvaloniaProperty.Register<BreadcrumbItem, object?>(
+        nameof(CommandParameter));
+
+    public object? CommandParameter
+    {
+        get => GetValue(CommandParameterProperty);
+        set => SetValue(CommandParameterProperty, value);
+    }
+
     public static readonly StyledProperty<IDataTemplate?> IconTemplateProperty = AvaloniaProperty.Register<BreadcrumbItem, IDataTemplate?>(
         nameof(IconTemplate));
 
@@ -62,7 +71,7 @@ public class BreadcrumbItem: ContentControl
         base.OnPointerPressed(e);
         if (!IsReadOnly)
         {
-            Command?.Execute(null);
+            Command?.Execute(CommandParameter);
         }
     }
 }


### PR DESCRIPTION
This PR attempts to add support for a command parameter for `BreadcrumbItem`, and its binding for `Breadcrubm`. The added property allows user code to distinguish between breadcrumb items when binding a Command to a common command located in the DataContext, by passing data from each breadcrumb item through the binding of `CommandParameter` / `CommandParameterBinding`.

---

## Preview

This PR does not change the sample code in the demo, which should also work without any changes.

To test the scenario demonstrated above, it's possible to apply the patch below:

<details>
  <summary>Patching code</summary>

```diff
Index: demo/Ursa.Demo/Pages/BreadcrumbDemo.axaml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/demo/Ursa.Demo/Pages/BreadcrumbDemo.axaml b/demo/Ursa.Demo/Pages/BreadcrumbDemo.axaml
--- a/demo/Ursa.Demo/Pages/BreadcrumbDemo.axaml	(revision 591d53cbd3e4238aca5d4cdb58398d4162c0b125)
+++ b/demo/Ursa.Demo/Pages/BreadcrumbDemo.axaml	(date 1724220008662)
@@ -39,7 +39,8 @@
         <u:Breadcrumb
             DisplayMemberBinding="{Binding Section}"
             IconBinding="{Binding Icon}"
-            CommandBinding="{Binding Command}"
+            CommandBinding="{Binding $parent[u:Breadcrumb].((vm:BreadcrumbDemoViewModel)DataContext).Command, FallbackValue={x:Null}}"
+            CommandParameterBinding="{Binding Section}"
             ItemsSource="{Binding Items1}">
             <u:Breadcrumb.Styles>
                 <Style Selector="u|BreadcrumbItem" x:DataType="vm:BreadcrumbDemoItem">
Index: demo/Ursa.Demo/ViewModels/BreadcrumbDemoViewModel.cs
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/demo/Ursa.Demo/ViewModels/BreadcrumbDemoViewModel.cs b/demo/Ursa.Demo/ViewModels/BreadcrumbDemoViewModel.cs
--- a/demo/Ursa.Demo/ViewModels/BreadcrumbDemoViewModel.cs	(revision 591d53cbd3e4238aca5d4cdb58398d4162c0b125)
+++ b/demo/Ursa.Demo/ViewModels/BreadcrumbDemoViewModel.cs	(date 1724220105245)
@@ -16,6 +16,16 @@
         new BreadcrumbDemoItem { Section = "Page 3", Icon = "Page" },
         new BreadcrumbDemoItem { Section = "Page 4", Icon = "Page", IsReadOnly = true }
     ];
+
+    public ICommand Command { get; }
+
+    public BreadcrumbDemoViewModel()
+    {
+        Command = new AsyncRelayCommand<string>(async section =>
+        {
+            await MessageBox.ShowOverlayAsync(section ?? string.Empty);
+        });
+    }
 }
 
 public partial class BreadcrumbDemoItem: ObservableObject
@@ -23,14 +33,4 @@
     public string? Section { get; set; }
     public string? Icon { get; set; }
     [ObservableProperty] private bool _isReadOnly;
-    
-    public ICommand Command { get; set; }
-
-    public BreadcrumbDemoItem()
-    {
-        Command = new AsyncRelayCommand(async () =>
-        {
-            await MessageBox.ShowOverlayAsync(Section ?? string.Empty);
-        });
-    }
 }
\ No newline at end of file

```

</details>

![image](https://github.com/user-attachments/assets/3d7d252f-bc00-4a74-8deb-6038db503490)

---

## API Changes

```diff
+ BreadcrumbItem.CommandParameterProperty
+ BreadcrumbItem.CommandParameter
+ Breadcrumb.CommandParameterBindingProperty
+ Breadcrumb.CommandParameterBinding
```

No breaking changes will be introduced.
