### PR TITLE
Change messagebox default button param to `OK`

### DIFF
--- a/src/Ursa/Controls/MessageBox/MessageBox.cs
+++ b/src/Ursa/Controls/MessageBox/MessageBox.cs
@@ -10,7 +10,7 @@ public static class MessageBox
         string message,
         string? title = null,
         MessageBoxIcon icon = MessageBoxIcon.None,
-        MessageBoxButton button = MessageBoxButton.OKCancel)
+        MessageBoxButton button = MessageBoxButton.OK)
     {
         var messageWindow = new MessageBoxWindow(button)
         {
@@ -36,7 +36,7 @@ public static class MessageBox
         string message,
         string title,
         MessageBoxIcon icon = MessageBoxIcon.None,
-        MessageBoxButton button = MessageBoxButton.OKCancel)
+        MessageBoxButton button = MessageBoxButton.OK)
     {
         var messageWindow = new MessageBoxWindow(button)
         {
@@ -53,7 +53,7 @@ public static class MessageBox
         string? title = null,
         string? hostId = null,
         MessageBoxIcon icon = MessageBoxIcon.None,
-        MessageBoxButton button = MessageBoxButton.OKCancel,
+        MessageBoxButton button = MessageBoxButton.OK,
         int? toplevelHashCode = null)
     {
         var host = OverlayDialogManager.GetHost(hostId, toplevelHashCode);


### PR DESCRIPTION
This is to match the WPF MessageBox default behavior.

No binary breaking change, but behavior change. 