### PR TITLE
Fix empty resource issue in en-US localization dictionary. 

### DIFF
--- a/src/Ursa.Themes.Semi/Locale/en-us.axaml.cs
+++ b/src/Ursa.Themes.Semi/Locale/en-us.axaml.cs
@@ -1,8 +1,13 @@
 using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
 
 namespace Ursa.Themes.Semi.Locale;
 
 public class en_us: ResourceDictionary
 {
-    
+    public en_us()
+    {
+        AvaloniaXamlLoader.Load(this);
+        this["STRING_PAGINATION_PAGE"] = string.Empty;
+    }
 }


### PR DESCRIPTION
This is a temporary fix because XAMLX ignores empty string resource.
Should be reverted after https://github.com/AvaloniaUI/Avalonia/issues/16659 is resolved. 