### PR TITLE
Fix Timepicker issues

### DIFF
--- a/demo/Ursa.Demo/Pages/TimePickerDemo.axaml
+++ b/demo/Ursa.Demo/Pages/TimePickerDemo.axaml
@@ -5,12 +5,16 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:u="https://irihi.tech/ursa"
+    xmlns:viewModels="clr-namespace:Ursa.Demo.ViewModels"
     d:DesignHeight="450"
     d:DesignWidth="800"
+    x:DataType="viewModels:TimePickerDemoViewModel"
     mc:Ignorable="d">
     <StackPanel HorizontalAlignment="Left">
         <ToggleSwitch Name="needConfirm" Content="Need Confirm" />
+        <!--
         <TextBlock Text="{Binding #picker.SelectedTime}" />
+        -->
         <TextBox
             Name="displayFormat"
             Width="300"
@@ -21,6 +25,7 @@
             Width="300"
             InnerLeftContent="Panel Format"
             Text="tt HH mm ss" />
+        <!--
         <u:TimePicker
             Name="picker"
             Width="200"
@@ -40,6 +45,20 @@
             PanelFormat="{Binding #panelFormat.Text}" />
         <u:TimeRangePicker
             Width="300"
+            DisplayFormat="{Binding #displayFormat.Text}"
+            PanelFormat="{Binding #panelFormat.Text}" />
+        -->
+        <TextBlock Text="Binding"/>
+        <u:TimePicker
+            Width="300"
+            HorizontalAlignment="Left"
+            SelectedTime="{Binding Time}"
+            DisplayFormat="{Binding #displayFormat.Text}"
+            PanelFormat="{Binding #panelFormat.Text}" />
+        <u:TimeRangePicker
+            Width="300"
+            StartTime="{Binding StartTime}"
+            EndTime="{Binding EndTime}"
             DisplayFormat="{Binding #displayFormat.Text}"
             PanelFormat="{Binding #panelFormat.Text}" />
     </StackPanel>

--- a/demo/Ursa.Demo/Pages/TimePickerDemo.axaml
+++ b/demo/Ursa.Demo/Pages/TimePickerDemo.axaml
@@ -12,9 +12,9 @@
     mc:Ignorable="d">
     <StackPanel HorizontalAlignment="Left">
         <ToggleSwitch Name="needConfirm" Content="Need Confirm" />
-        <!--
+        
         <TextBlock Text="{Binding #picker.SelectedTime}" />
-        -->
+        
         <TextBox
             Name="displayFormat"
             Width="300"
@@ -25,7 +25,7 @@
             Width="300"
             InnerLeftContent="Panel Format"
             Text="tt HH mm ss" />
-        <!--
+        
         <u:TimePicker
             Name="picker"
             Width="200"
@@ -47,7 +47,7 @@
             Width="300"
             DisplayFormat="{Binding #displayFormat.Text}"
             PanelFormat="{Binding #panelFormat.Text}" />
-        -->
+        
         <TextBlock Text="Binding"/>
         <u:TimePicker
             Width="300"

--- a/demo/Ursa.Demo/ViewModels/TimePickerDemoViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/TimePickerDemoViewModel.cs
@@ -1,8 +1,18 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace Ursa.Demo.ViewModels;
 
-public class TimePickerDemoViewModel: ObservableObject
+public partial class TimePickerDemoViewModel: ObservableObject
 {
-    
+    [ObservableProperty] private TimeSpan? _time;
+    [ObservableProperty] private TimeSpan? _startTime;
+    [ObservableProperty] private TimeSpan? _endTime;
+
+    public TimePickerDemoViewModel()
+    {
+        Time = new TimeSpan(12, 20, 0);
+        StartTime = new TimeSpan(8, 21, 0);
+        EndTime = new TimeSpan(18, 22, 0);
+    }
 }

--- a/src/Ursa.Themes.Semi/Controls/TimePicker.axaml
+++ b/src/Ursa.Themes.Semi/Controls/TimePicker.axaml
@@ -193,8 +193,7 @@
                                         <u:TimePickerPresenter
                                             Name="{x:Static u:TimePicker.PART_Presenter}"
                                             NeedsConfirmation="{TemplateBinding NeedConfirmation}"
-                                            PanelFormat="{TemplateBinding PanelFormat}"
-                                            Time="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=SelectedTime, Mode=OneWayToSource}" />
+                                            PanelFormat="{TemplateBinding PanelFormat}"/>
                                     </DockPanel>
                                 </Border>
                             </Popup>

--- a/src/Ursa.Themes.Semi/Controls/TimeRangePicker.axaml
+++ b/src/Ursa.Themes.Semi/Controls/TimeRangePicker.axaml
@@ -141,7 +141,7 @@
                                             Grid.Column="0"
                                             NeedsConfirmation="{TemplateBinding NeedConfirmation}"
                                             PanelFormat="{TemplateBinding PanelFormat}"
-                                            Time="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=StartTime, Mode=OneWayToSource}" />
+                                            />
                                         <Rectangle
                                             Grid.Row="2"
                                             Grid.Column="1"
@@ -155,7 +155,7 @@
                                             Grid.Column="2"
                                             NeedsConfirmation="{TemplateBinding NeedConfirmation}"
                                             PanelFormat="{TemplateBinding PanelFormat}"
-                                            Time="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EndTime, Mode=OneWayToSource}" />
+                                            />
                                     </Grid>
                                 </DockPanel>
                             </Border>

--- a/src/Ursa/Controls/DateTimePicker/TimeChangedEventArgs.cs
+++ b/src/Ursa/Controls/DateTimePicker/TimeChangedEventArgs.cs
@@ -1,0 +1,16 @@
+using Avalonia.Interactivity;
+
+namespace Ursa.Controls;
+
+public class TimeChangedEventArgs:RoutedEventArgs
+{
+    public TimeSpan? OldTime { get; }
+
+    public TimeSpan? NewTime { get; }
+
+    public TimeChangedEventArgs(TimeSpan? oldTime, TimeSpan? newTime)
+    {
+        this.OldTime = oldTime;
+        this.NewTime = newTime;
+    }
+}

--- a/src/Ursa/Controls/DateTimePicker/TimeRangePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/TimeRangePicker.cs
@@ -57,7 +57,21 @@ public class TimeRangePicker : TimePickerBase, IClearControl
             picker.OnSelectionChanged(args));
         EndTimeProperty.Changed.AddClassHandler<TimeRangePicker, TimeSpan?>((picker, args) =>
             picker.OnSelectionChanged(args, false));
+        DisplayFormatProperty.Changed.AddClassHandler<TimeRangePicker, string?>((picker, args) => picker.OnDisplayFormatChanged(args));
     }
+
+    private void OnDisplayFormatChanged(AvaloniaPropertyChangedEventArgs<string?> args)
+    {
+        if (_startTextBox is not null)
+        {
+            SyncTimeToText(StartTime);
+        }
+        if (_endTextBox is not null)
+        {
+            SyncTimeToText(EndTime, false);
+        }
+    }
+
 
     public string? EndWatermark
     {


### PR DESCRIPTION
This PR is to fix timepicker initialization issue. 

### Implementation

1. for easier handling, TimePicker.SelectedTimeChanged event is now routed event, a new EventArg is created for this event. 
2. Instead of directly binding to template parent, TimePicker now handles presenter time in code behind. 
3. Extract TimeToText process and call it once after template applied. 
4. DisplayFormat now triggers text update immediately for TimeRangePicker. 