### PR TITLE
refactor ThemeSelectorBase and ThemeToggleButton

### DIFF
--- a/src/Ursa/Controls/ThemeSelector/ThemeToggleButton.cs
+++ b/src/Ursa/Controls/ThemeSelector/ThemeToggleButton.cs
@@ -41,57 +41,50 @@ public class ThemeToggleButton: ThemeSelectorBase
 
     private void OnButtonClicked(object? sender, RoutedEventArgs e)
     {
-        bool? currentState = _state;
-        if (IsThreeState)
+        if (Mode == ThemeSelectorMode.Indicator || !IsThreeState)
         {
-            _state = currentState switch
-            {
-                true => false,
-                false => null,
-                null => true,
-            };
-        }
-        else
-        {
-            _state = currentState switch
+            _state = _state switch
             {
                 true => false,
                 false => true,
-                null => true,
+                null => throw new InvalidOperationException("Invalid state")
             };
-        }
-        if (_state == true)
-        {
-            SelectedTheme = ThemeVariant.Light;
-        }
-        else if (_state == false)
-        {
-            SelectedTheme = ThemeVariant.Dark;
-        }
+        } 
         else
         {
-            SelectedTheme = ThemeVariant.Default;
+            _state = _state switch
+            {
+                true => false,
+                false => null,
+                null => true
+            };
         }
-
-        if (Mode == ThemeSelectorMode.Controller)
+        
+        SelectedTheme = _state switch
         {
-            PseudoClasses.Set(PC_Light, SelectedTheme == ThemeVariant.Light);
-            PseudoClasses.Set(PC_Dark, SelectedTheme == ThemeVariant.Dark);
-            PseudoClasses.Set(PC_Default, SelectedTheme == null || SelectedTheme == ThemeVariant.Default);
-        }
+            true => ThemeVariant.Light,
+            false => ThemeVariant.Dark,
+            null => ThemeVariant.Default
+        };
+        
+        PseudoClasses.Set(PC_Light, SelectedTheme == ThemeVariant.Light);
+        PseudoClasses.Set(PC_Dark, SelectedTheme == ThemeVariant.Dark);
+        PseudoClasses.Set(PC_Default, SelectedTheme == ThemeVariant.Default);
     }
 
     protected override void SyncThemeFromScope(ThemeVariant? theme)
     {
         base.SyncThemeFromScope(theme);
-        if (Mode == ThemeSelectorMode.Indicator)
+        if (!IsThreeState && theme is null)
         {
-            PseudoClasses.Set(PC_Light, theme == ThemeVariant.Light);
-            PseudoClasses.Set(PC_Dark, theme == ThemeVariant.Dark);
-            PseudoClasses.Set(PC_Default, theme == null || SelectedTheme == ThemeVariant.Default);
-            if (theme == ThemeVariant.Dark) _state = false;
-            else if (theme == ThemeVariant.Light) _state = true;
-            else _state = null;
+            theme = ThemeVariant.Light;
         }
+        
+        PseudoClasses.Set(PC_Light, theme == ThemeVariant.Light);
+        PseudoClasses.Set(PC_Dark, theme == ThemeVariant.Dark);
+        PseudoClasses.Set(PC_Default, theme == null || SelectedTheme == ThemeVariant.Default);
+        if (theme == ThemeVariant.Dark) _state = false;
+        else if (theme == ThemeVariant.Light) _state = true;
+        else _state = null;
     }
 }


### PR DESCRIPTION
close #340 

## Changes
1. Remove _scope variable in ThemeSelectorBase, only use TargetScope
2. When `ThemeToggleButton` is in `Indicator` mode or not enabled `IsThreeState`, the button is only available for Light mode and Dark mode switch
3. When `ThemeToggleButton` is in `Controller` mode and enabled `IsThreeState`, the theme will switch following the order: Default, Light, Dark
4. Remove the null check for setting the default pseudo class in `OnButtonClicked` because `SelectedTheme` will always have a value
5. add special check in `SyncThemeFromScope` when `IsThreeState` not enabled and theme is null, setting the default to Light theme