### PR TITLE
Introduce IsSelectable for TreeComboBoxItem.

### DIFF
--- a/demo/Ursa.Demo/Pages/TreeComboBoxDemo.axaml
+++ b/demo/Ursa.Demo/Pages/TreeComboBoxDemo.axaml
@@ -52,6 +52,11 @@
             PopupInnerTopContent="Top"
             PopupInnerBottomContent="Bottom"
             ItemsSource="{Binding Items}">
+            <u:TreeComboBox.Styles>
+                <Style Selector="u|TreeComboBoxItem" x:DataType="vm:TreeComboBoxItemViewModel">
+                    <Setter Property="IsSelectable" Value="{Binding IsSelectable}"/>
+                </Style>
+            </u:TreeComboBox.Styles>
             <u:TreeComboBox.ItemTemplate>
                 <TreeDataTemplate ItemsSource="{Binding Children}">
                     <TextBlock Text="{Binding ItemName}" />

--- a/demo/Ursa.Demo/ViewModels/TreeComboBoxDemoViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/TreeComboBoxDemoViewModel.cs
@@ -19,7 +19,8 @@ public partial class TreeComboBoxDemoViewModel: ObservableObject
                 {
                     new TreeComboBoxItemViewModel()
                     {
-                        ItemName = "Item 1-1",
+                        ItemName = "Item 1-1 (Not selectable)",
+                        IsSelectable = false,
                         Children = new List<TreeComboBoxItemViewModel>()
                         {
                             new TreeComboBoxItemViewModel()
@@ -45,7 +46,8 @@ public partial class TreeComboBoxDemoViewModel: ObservableObject
                 {
                     new TreeComboBoxItemViewModel()
                     {
-                        ItemName = "Item 2-1"
+                        ItemName = "Item 2-1  (Not selectable)",
+                        IsSelectable = false,
                     },
                     new TreeComboBoxItemViewModel()
                     {
@@ -64,5 +66,6 @@ public partial class TreeComboBoxDemoViewModel: ObservableObject
 public partial class TreeComboBoxItemViewModel : ObservableObject
 {
     [ObservableProperty] private string? _itemName;
+    [ObservableProperty] private bool _isSelectable = true;
     public List<TreeComboBoxItemViewModel> Children { get; set; } = new ();
 }

--- a/src/Ursa.Themes.Semi/Controls/TreeComboBox.axaml
+++ b/src/Ursa.Themes.Semi/Controls/TreeComboBox.axaml
@@ -217,6 +217,7 @@
         <Setter Property="Background" Value="{DynamicResource TreeViewItemDefaultBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource TreeViewItemDefaultForeground}" />
         <Setter Property="CornerRadius" Value="3" />
+        <Setter Property="MinHeight" Value="32"></Setter>
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="Template">
             <ControlTemplate TargetType="u:TreeComboBoxItem">

--- a/src/Ursa/Controls/ComboBox/TreeComboBox.cs
+++ b/src/Ursa/Controls/ComboBox/TreeComboBox.cs
@@ -198,7 +198,7 @@ public class TreeComboBox: ItemsControl, IClearControl, IInnerContentControl, IP
             if (_popup is not null && _popup.IsOpen && _popup.IsInsidePopup(source))
             {
                 var container = GetContainerFromEventSource(source);
-                if (container is null) return;
+                if (container is null || !container.IsSelectable) return;
                 var item = TreeItemFromContainer(container);
                 if (item is null) return;
                 if (SelectedItem is not null)

--- a/src/Ursa/Controls/ComboBox/TreeComboBoxItem.cs
+++ b/src/Ursa/Controls/ComboBox/TreeComboBoxItem.cs
@@ -33,6 +33,15 @@ public class TreeComboBoxItem: HeaderedItemsControl, ISelectable
         set => SetValue(IsExpandedProperty, value);
     }
 
+    public static readonly StyledProperty<bool> IsSelectableProperty = AvaloniaProperty.Register<TreeComboBoxItem, bool>(
+        nameof(IsSelectable), true);
+
+    public bool IsSelectable
+    {
+        get => GetValue(IsSelectableProperty);
+        set => SetValue(IsSelectableProperty, value);
+    }
+
     
 
     public static readonly DirectProperty<TreeComboBoxItem, int> LevelProperty = AvaloniaProperty.RegisterDirect<TreeComboBoxItem, int>(


### PR DESCRIPTION
TreeComboBox now exposes a property to control whether the node is selectable.

If selectable, then selectable (

If not selectable, user can only click on expander chevron to expand and collapse the node, 