### PR TITLE
Introduce IsTopLevel to OverlayDialogHost

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
@@ -66,7 +66,7 @@
                                 LeftContent="{Binding $parent[u:UrsaWindow].LeftContent}"
                                 RightContent="{Binding $parent[u:UrsaWindow].RightContent}" />
                             <VisualLayerManager>
-                                <u:OverlayDialogHost IsModalStatusReporter="True" />
+                                <u:OverlayDialogHost IsTopLevel="True" IsModalStatusReporter="True" />
                             </VisualLayerManager>
                         </VisualLayerManager.ChromeOverlayLayer>
                         <Panel>

--- a/src/Ursa/Controls/OverlayShared/OverlayDialogHost.Dialog.cs
+++ b/src/Ursa/Controls/OverlayShared/OverlayDialogHost.Dialog.cs
@@ -72,7 +72,7 @@ public partial class OverlayDialogHost
     {
         if (e.Source is DialogControlBase item)
         {
-            if (item.IsFullScreen)
+            if (IsTopLevel && item.IsFullScreen)
             {
                 var top = TopLevel.GetTopLevel(item);
                 if (top is Window w)

--- a/src/Ursa/Controls/OverlayShared/OverlayDialogHost.Shared.cs
+++ b/src/Ursa/Controls/OverlayShared/OverlayDialogHost.Shared.cs
@@ -56,6 +56,7 @@ public partial class OverlayDialogHost: Canvas
     }
     
     public bool IsAnimationDisabled { get; set; }
+    public bool IsTopLevel { get; set; }
     
     static OverlayDialogHost()
     {
@@ -114,7 +115,7 @@ public partial class OverlayDialogHost: Canvas
         {
             rec.AddHandler(PointerReleasedEvent, ClickMaskToCloseDialog);
         }
-        else
+        else if(IsTopLevel)
         {
             rec.AddHandler(PointerPressedEvent, DragMaskToMoveWindow);
         }


### PR DESCRIPTION
Behaviors that interacts with top level window will only be enabled when you set this flag to true. Including:
* Drag Window with overlay mask
* Drag Window with full screen dialog

Any host can be IsToplevel = true, it doesn't have to be in the window template. 