### PR TITLE
Introduce Resizer for UrsaWindow

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/Resizer.axaml
+++ b/src/Ursa.Themes.Semi/Controls/Resizer.axaml
@@ -1,0 +1,31 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:u="https://irihi.tech/ursa"
+                    xmlns:iri="https://irihi.tech/shared">
+    <!-- Add Resources Here -->
+    <ControlTheme TargetType="u:WindowResizerThumb" x:Key="{x:Type u:WindowResizerThumb}">
+        <Setter Property="Background" Value="Transparent" />
+        <Setter Property="Template">
+            <ControlTemplate TargetType="u:WindowResizerThumb">
+                <iri:PureRectangle HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Background="{TemplateBinding Background}"/>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+    
+    <ControlTheme TargetType="u:WindowResizer" x:Key="{x:Type u:WindowResizer}">
+        <Setter Property="Template">
+            <ControlTemplate TargetType="u:WindowResizer">
+                <Grid RowDefinitions="Auto, *, Auto" ColumnDefinitions="Auto, *, Auto" >
+                    <u:WindowResizerThumb Grid.Row="0" Grid.Column="0" ResizeDirection="TopLeft" Cursor="TopLeftCorner" />
+                    <u:WindowResizerThumb Grid.Row="0" Grid.Column="1" ResizeDirection="Top" Cursor="TopSide" Height="{DynamicResource ResizerThumbHeight}" />
+                    <u:WindowResizerThumb Grid.Row="0" Grid.Column="2" ResizeDirection="TopRight" Cursor="TopRightCorner" />
+                    <u:WindowResizerThumb Grid.Row="1" Grid.Column="0" ResizeDirection="Left" Cursor="LeftSide" Width="{DynamicResource ResizerThumbWidth}" />
+                    <u:WindowResizerThumb Grid.Row="1" Grid.Column="2" ResizeDirection="Right" Cursor="RightSide" Width="{DynamicResource ResizerThumbWidth}" />
+                    <u:WindowResizerThumb Grid.Row="2" Grid.Column="0" ResizeDirection="BottomLeft" Cursor="BottomLeftCorner" />
+                    <u:WindowResizerThumb Grid.Row="2" Grid.Column="1" ResizeDirection="Bottom" Cursor="BottomSide" Height="{DynamicResource ResizerThumbHeight}" />
+                    <u:WindowResizerThumb Grid.Row="2" Grid.Column="2" ResizeDirection="BottomRight" Cursor="BottomRightCorner" />
+                </Grid>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
@@ -71,7 +71,13 @@
                                 LeftContent="{Binding $parent[u:UrsaWindow].LeftContent}"
                                 RightContent="{Binding $parent[u:UrsaWindow].RightContent}" />
                             <VisualLayerManager>
-                                <u:OverlayDialogHost IsTopLevel="True" IsModalStatusReporter="True" />
+                                <Panel>
+                                    <u:OverlayDialogHost IsModalStatusReporter="True" IsTopLevel="True" />
+                                    <u:WindowResizer
+                                        HorizontalAlignment="Stretch"
+                                        VerticalAlignment="Stretch"
+                                        IsVisible="{Binding $parent[u:UrsaWindow].IsManagedResizerVisible}" />
+                                </Panel>
                             </VisualLayerManager>
                         </VisualLayerManager.ChromeOverlayLayer>
                         <Panel>
@@ -82,6 +88,7 @@
                                 VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
                                 Content="{TemplateBinding Content}"
                                 ContentTemplate="{TemplateBinding ContentTemplate}" />
+
                         </Panel>
                     </VisualLayerManager>
                 </Panel>

--- a/src/Ursa.Themes.Semi/Controls/_index.axaml
+++ b/src/Ursa.Themes.Semi/Controls/_index.axaml
@@ -37,6 +37,7 @@
         <ResourceInclude Source="Pagination.axaml" />
         <ResourceInclude Source="RangeSlider.axaml" />
         <ResourceInclude Source="Rating.axaml" />
+        <ResourceInclude Source="Resizer.axaml" />
         <ResourceInclude Source="ScrollToButton.axaml" />
         <ResourceInclude Source="SelectionList.axaml" />
         <ResourceInclude Source="TagInput.axaml" />

--- a/src/Ursa.Themes.Semi/Themes/Shared/Resizer.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Shared/Resizer.axaml
@@ -1,0 +1,6 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <!-- Add Resources Here -->
+    <x:Double x:Key="ResizerThumbWidth">6</x:Double>
+    <x:Double x:Key="ResizerThumbHeight">6</x:Double>
+</ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Themes/Shared/_index.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Shared/_index.axaml
@@ -1,29 +1,30 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <ResourceDictionary.MergedDictionaries>
-        <MergeResourceInclude Source="Avatar.axaml" />
-        <MergeResourceInclude Source="Badge.axaml" />
-        <MergeResourceInclude Source="Banner.axaml" />
-        <MergeResourceInclude Source="ButtonGroup.axaml" />
-        <MergeResourceInclude Source="DatePicker.axaml" />
-        <MergeResourceInclude Source="DateTimePicker.axaml" />
-        <MergeResourceInclude Source="Dialog.axaml" />
-        <MergeResourceInclude Source="DialogShared.axaml" />
-        <MergeResourceInclude Source="Divider.axaml" />
-        <MergeResourceInclude Source="Drawer.axaml" />
-        <MergeResourceInclude Source="DualBadge.axaml" />
-        <MergeResourceInclude Source="IPv4Box.axaml" />
-        <MergeResourceInclude Source="KeyGestureInput.axaml" />
-        <MergeResourceInclude Source="MessageBox.axaml" />
-        <MergeResourceInclude Source="NavigationMenu.axaml" />
-        <MergeResourceInclude Source="Notification.axaml" />
-        <MergeResourceInclude Source="Pagination.axaml" />
-        <MergeResourceInclude Source="Rating.axaml" />
-        <MergeResourceInclude Source="ScrollToButton.axaml" />
-        <MergeResourceInclude Source="TagInput.axaml" />
-        <MergeResourceInclude Source="Skeleton.axaml" />
-        <MergeResourceInclude Source="ThemeSelector.axaml" />
-        <MergeResourceInclude Source="Toast.axaml" />
-        <MergeResourceInclude Source="ToolBar.axaml" />
-        <MergeResourceInclude Source="TimeBox.axaml" />
+        <ResourceInclude Source="Avatar.axaml" />
+        <ResourceInclude Source="Badge.axaml" />
+        <ResourceInclude Source="Banner.axaml" />
+        <ResourceInclude Source="ButtonGroup.axaml" />
+        <ResourceInclude Source="DatePicker.axaml" />
+        <ResourceInclude Source="DateTimePicker.axaml" />
+        <ResourceInclude Source="Dialog.axaml" />
+        <ResourceInclude Source="DialogShared.axaml" />
+        <ResourceInclude Source="Divider.axaml" />
+        <ResourceInclude Source="Drawer.axaml" />
+        <ResourceInclude Source="DualBadge.axaml" />
+        <ResourceInclude Source="IPv4Box.axaml" />
+        <ResourceInclude Source="KeyGestureInput.axaml" />
+        <ResourceInclude Source="MessageBox.axaml" />
+        <ResourceInclude Source="NavigationMenu.axaml" />
+        <ResourceInclude Source="Notification.axaml" />
+        <ResourceInclude Source="Pagination.axaml" />
+        <ResourceInclude Source="Rating.axaml" />
+        <ResourceInclude Source="Resizer.axaml"/>
+        <ResourceInclude Source="ScrollToButton.axaml" />
+        <ResourceInclude Source="TagInput.axaml" />
+        <ResourceInclude Source="Skeleton.axaml" />
+        <ResourceInclude Source="ThemeSelector.axaml" />
+        <ResourceInclude Source="Toast.axaml" />
+        <ResourceInclude Source="ToolBar.axaml" />
+        <ResourceInclude Source="TimeBox.axaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/Ursa/Controls/Resizers/ResizeDirection.cs
+++ b/src/Ursa/Controls/Resizers/ResizeDirection.cs
@@ -1,0 +1,13 @@
+namespace Ursa.Controls;
+
+public enum ResizeDirection
+{
+    Top,
+    Bottom,
+    Left,
+    Right,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}

--- a/src/Ursa/Controls/Resizers/WindowResizer.cs
+++ b/src/Ursa/Controls/Resizers/WindowResizer.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls.Primitives;
+
+namespace Ursa.Controls;
+
+public class WindowResizer : TemplatedControl
+{
+    
+}

--- a/src/Ursa/Controls/Resizers/WindowResizerThumb.cs
+++ b/src/Ursa/Controls/Resizers/WindowResizerThumb.cs
@@ -1,0 +1,45 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+
+namespace Ursa.Controls;
+
+public class WindowResizerThumb: Thumb
+{
+    private Window? _window;
+    
+    public static readonly StyledProperty<ResizeDirection> ResizeDirectionProperty = AvaloniaProperty.Register<WindowResizerThumb, ResizeDirection>(
+        nameof(ResizeDirection));
+
+    public ResizeDirection ResizeDirection
+    {
+        get => GetValue(ResizeDirectionProperty);
+        set => SetValue(ResizeDirectionProperty, value);
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+        _window = TopLevel.GetTopLevel(this) as Window;
+    }
+
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        if (_window is null || !_window.CanResize) return;
+        var windowEdge = ResizeDirection switch
+        {
+            ResizeDirection.Top => WindowEdge.North,
+            ResizeDirection.TopRight => WindowEdge.NorthEast,
+            ResizeDirection.Right => WindowEdge.East,
+            ResizeDirection.BottomRight => WindowEdge.SouthEast,
+            ResizeDirection.Bottom => WindowEdge.South,
+            ResizeDirection.BottomLeft => WindowEdge.SouthWest,
+            ResizeDirection.Left => WindowEdge.West,
+            ResizeDirection.TopLeft => WindowEdge.NorthWest,
+            _ => throw new ArgumentOutOfRangeException()
+        };
+        _window.BeginResizeDrag(windowEdge, e);
+    }
+}

--- a/src/Ursa/Controls/Resizers/WindowResizerThumb.cs
+++ b/src/Ursa/Controls/Resizers/WindowResizerThumb.cs
@@ -28,6 +28,8 @@ public class WindowResizerThumb: Thumb
     {
         base.OnPointerPressed(e);
         if (_window is null || !_window.CanResize) return;
+        // TODO: Support touch screen resizing but we don't know what it should behave. 
+        if (!e.GetCurrentPoint(this).Properties.IsLeftButtonPressed) return;
         var windowEdge = ResizeDirection switch
         {
             ResizeDirection.Top => WindowEdge.North,

--- a/src/Ursa/Windows/UrsaWindow.cs
+++ b/src/Ursa/Windows/UrsaWindow.cs
@@ -54,6 +54,15 @@ public class UrsaWindow: Window
         get => GetValue(IsTitleBarVisibleProperty);
         set => SetValue(IsTitleBarVisibleProperty, value);
     }
+
+    public static readonly StyledProperty<bool> IsManagedResizerVisibleProperty = AvaloniaProperty.Register<UrsaWindow, bool>(
+        nameof(IsManagedResizerVisible));
+
+    public bool IsManagedResizerVisible
+    {
+        get => GetValue(IsManagedResizerVisibleProperty);
+        set => SetValue(IsManagedResizerVisibleProperty, value);
+    }
     
     public static readonly StyledProperty<object?> TitleBarContentProperty = AvaloniaProperty.Register<UrsaWindow, object?>(
         nameof(TitleBarContent));


### PR DESCRIPTION
In some Linux env, borderless Window must consume `SystemDecorations=None`, but this will disable window resizing. This PR introduce WindowResizer, and a new property `IsManagedRezierVisible` in UrsaWindow, so user can enable resizing without SystemDecoration border. 