### PR TITLE
Add Nuget packaging for Prism and ReactiveUI extensions

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -18,6 +18,12 @@ jobs:
 
       - name: Nuget Ursa.Themes.Semi
         run: dotnet pack ./src/Ursa.Themes.Semi -o ./nugets
+        
+      - name: Nuget Prism Extension
+        run: dotnet pack ./src/Ursa.PrismExtension -o ./nugets
+        
+      - name: Nuget ReactiveUI Extension
+        run: dotnet pack ./src/Ursa.ReactiveUI -o ./nugets
 
       - name: Upload a Build Artifact
         uses: actions/upload-artifact@v4.3.1

--- a/src/Ursa.PrismExtension/Ursa.PrismExtension.csproj
+++ b/src/Ursa.PrismExtension/Ursa.PrismExtension.csproj
@@ -4,12 +4,14 @@
     
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Version>1.0.0</Version>
+        <Version>1.0.1</Version>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
         <PackageId>Irihi.Ursa.PrismExtension</PackageId>
         <PackageIcon>irihi.png</PackageIcon>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Ursa.ReactiveUI/Ursa.ReactiveUIExtension.csproj
+++ b/src/Ursa.ReactiveUI/Ursa.ReactiveUIExtension.csproj
@@ -1,32 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<LangVersion>latest</LangVersion>
-		<Authors>WCKYWCKF, IRIHI Technology</Authors>
-		<PackageId>Irihi.Ursa.ReactiveUIExtension</PackageId>
-		<PackageIcon>irihi.png</PackageIcon>
-		<PackageProjectUrl>https://github.com/irihitech/Ursa.Avalonia</PackageProjectUrl>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<Nullable>enable</Nullable>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Description>This is a Ursa expansion. This package integrates and is compatible with UrsaWindow and UrsaView with Avalonia.ReactiveUI. [Avalonia.ReactiveUI See: https://docs.avaloniaui.net/zh-Hans/docs/concepts/reactiveui/]
+    <PropertyGroup>
+        <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <LangVersion>latest</LangVersion>
+        <Authors>WCKYWCKF, IRIHI Technology</Authors>
+        <PackageId>Irihi.Ursa.ReactiveUIExtension</PackageId>
+        <PackageIcon>irihi.png</PackageIcon>
+        <PackageProjectUrl>https://github.com/irihitech/Ursa.Avalonia</PackageProjectUrl>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <Nullable>enable</Nullable>
+        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+        <Description>This is a Ursa expansion. This package integrates and is compatible with UrsaWindow and UrsaView with Avalonia.ReactiveUI. [Avalonia.ReactiveUI See: https://docs.avaloniaui.net/zh-Hans/docs/concepts/reactiveui/]
 
-这个是一个Ursa拓展包。这个包整合并互相兼容了UrsaWindow和UrsaView与Avalonia.ReactiveUI的功能。【Avalonia.ReactiveUI参见：https://docs.avaloniaui.net/docs/concepts/reactiveui/】</Description>
-		<Version>1.0.1</Version>
-		<Copyright></Copyright>
-		<RepositoryUrl>https://github.com/irihitech/Ursa.Avalonia</RepositoryUrl>
-		<IncludeSymbols>true</IncludeSymbols>
-		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-	</PropertyGroup>
+            这个是一个Ursa拓展包。这个包整合并互相兼容了UrsaWindow和UrsaView与Avalonia.ReactiveUI的功能。【Avalonia.ReactiveUI参见：https://docs.avaloniaui.net/docs/concepts/reactiveui/】
+        </Description>
+        <Version>1.0.1</Version>
+        <Copyright></Copyright>
+        <RepositoryUrl>https://github.com/irihitech/Ursa.Avalonia</RepositoryUrl>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.1.1" />
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.1.1"/>
+    </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\Ursa\Ursa.csproj" />
-	</ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\Ursa\Ursa.csproj"/>
+        <None Include="irihi.png" Pack="true" PackagePath=""/>
+    </ItemGroup>
 
 </Project>

--- a/src/Ursa.ReactiveUI/Ursa.ReactiveUIExtension.csproj
+++ b/src/Ursa.ReactiveUI/Ursa.ReactiveUIExtension.csproj
@@ -17,6 +17,8 @@
 		<Version>1.0.1</Version>
 		<Copyright></Copyright>
 		<RepositoryUrl>https://github.com/irihitech/Ursa.Avalonia</RepositoryUrl>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/src/Ursa.Themes.Semi/Ursa.Themes.Semi.csproj
+++ b/src/Ursa.Themes.Semi/Ursa.Themes.Semi.csproj
@@ -11,6 +11,8 @@
         <PackageId>Irihi.Ursa.Themes.Semi</PackageId>
         <PackageIcon>irihi.png</PackageIcon>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
1. Add nuget packaging for two extension projects in workflow
2. Enable SourceLink
3. Bump Prism extension for next release. 