### PR TITLE
Enables Deterministic Builds

### DIFF
--- a/src/Package.props
+++ b/src/Package.props
@@ -8,4 +8,8 @@
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <PackageProjectUrl>https://github.com/irihitech/Ursa.Avalonia</PackageProjectUrl>
     </PropertyGroup>
+
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
 </Project>


### PR DESCRIPTION
The current built artifact health info:

![image](https://github.com/user-attachments/assets/35d7e7da-4549-4b7b-922e-31a2b106820a)


Setting `ContinuousIntegrationBuild` to `true` will enable deterministic builds feature.

See:

- [ContinuousIntegrationBuild - MSBuild properties for Microsoft.NET.Sdk - .NET | Microsoft Learn](https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#continuousintegrationbuild)
- [Source Link and .NET libraries - .NET | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink#:~:text=CONSIDER%20enabling%20deterministic%20builds.)
  > ✔️ CONSIDER enabling deterministic builds.