### PR TITLE
Fix DatePicker and DateRangePicker behaviour

### DIFF
--- a/src/Ursa/Controls/DateTimePicker/DatePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePicker.cs
@@ -7,6 +7,8 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.VisualTree;
+using Irihi.Avalonia.Shared.Common;
 using Irihi.Avalonia.Shared.Contracts;
 using Irihi.Avalonia.Shared.Helpers;
 
@@ -25,6 +27,7 @@ public class DatePicker: DatePickerBase, IClearControl
     private Button? _button;
     private TextBox? _textBox;
     private CalendarView? _calendar;
+    private Popup? _popup;
 
     public static readonly StyledProperty<DateTime?> SelectedDateProperty = AvaloniaProperty.Register<DatePicker, DateTime?>(
         nameof(SelectedDate), defaultBindingMode: BindingMode.TwoWay);
@@ -66,7 +69,7 @@ public class DatePicker: DatePickerBase, IClearControl
         CalendarView.DateSelectedEvent.RemoveHandler(OnDateSelected, _calendar);
         
         _button = e.NameScope.Find<Button>(PART_Button);
-        e.NameScope.Find<Popup>(PART_Popup);
+        _popup = e.NameScope.Find<Popup>(PART_Popup);
         _textBox = e.NameScope.Find<TextBox>(PART_TextBox);
         _calendar = e.NameScope.Find<CalendarView>(PART_Calendar);
         
@@ -171,12 +174,18 @@ public class DatePicker: DatePickerBase, IClearControl
         }
         SetCurrentValue(IsDropdownOpenProperty, true);
     }
-
-    protected override void OnLostFocus(RoutedEventArgs e)
+    
+    /// <inheritdoc/>
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
     {
-        base.OnLostFocus(e);
-        SetCurrentValue(IsDropdownOpenProperty, false);
-        SetSelectedDate();
+        base.OnPointerPressed(e);
+        if(!e.Handled && e.Source is Visual source)
+        {
+            if (_popup?.IsInsidePopup(source) == true)
+            {
+                e.Handled = true;
+            }
+        }
     }
 
     protected override void OnKeyDown(KeyEventArgs e)

--- a/src/Ursa/Controls/DateTimePicker/DatePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePicker.cs
@@ -190,27 +190,23 @@ public class DatePicker: DatePickerBase, IClearControl
 
     protected override void OnKeyDown(KeyEventArgs e)
     {
-        if (e.Key == Key.Escape)
+        switch (e.Key)
         {
-            SetCurrentValue(IsDropdownOpenProperty, false);
-            e.Handled = true;
-            return;
+            case Key.Escape:
+                SetCurrentValue(IsDropdownOpenProperty, false);
+                e.Handled = true;
+                return;
+            case Key.Down:
+                SetCurrentValue(IsDropdownOpenProperty, true);
+                e.Handled = true;
+                return;
+            case Key.Tab:
+                SetCurrentValue(IsDropdownOpenProperty, false);
+                return;
+            default:
+                base.OnKeyDown(e);
+                break;
         }
-
-        if (e.Key == Key.Down)
-        {
-            SetCurrentValue(IsDropdownOpenProperty, true);
-            e.Handled = true;
-            return;
-        }
-
-        if (e.Key == Key.Tab)
-        {
-            SetCurrentValue(IsDropdownOpenProperty, false);
-            return;
-        }
-
-        base.OnKeyDown(e);
     }
 
     public void Clear()

--- a/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
@@ -49,6 +49,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
     private bool? _start;
     private CalendarView? _startCalendar;
     private TextBox? _startTextBox;
+    private Popup? _popup;
 
     static DateRangePicker()
     {
@@ -139,7 +140,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
         }
 
         _button = e.NameScope.Find<Button>(PART_Button);
-        e.NameScope.Find<Popup>(PART_Popup);
+        _popup = e.NameScope.Find<Popup>(PART_Popup);
         _startCalendar = e.NameScope.Find<CalendarView>(PART_StartCalendar);
         _endCalendar = e.NameScope.Find<CalendarView>(PART_EndCalendar);
         _startTextBox = e.NameScope.Find<TextBox>(PART_StartTextBox);
@@ -398,6 +399,19 @@ public class DateRangePicker : DatePickerBase, IClearControl
             }
         }
     }
+    
+    /// <inheritdoc/>
+    protected override void OnPointerPressed(PointerPressedEventArgs e)
+    {
+        base.OnPointerPressed(e);
+        if(!e.Handled && e.Source is Visual source)
+        {
+            if (_popup?.IsInsidePopup(source) == true)
+            {
+                e.Handled = true;
+            }
+        }
+    }
 
     private void OnTextBoxGetFocus(object? sender, GotFocusEventArgs e)
     {
@@ -418,5 +432,32 @@ public class DateRangePicker : DatePickerBase, IClearControl
         SetCurrentValue(IsDropdownOpenProperty, true);
     }
     
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            SetCurrentValue(IsDropdownOpenProperty, false);
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Down)
+        {
+            SetCurrentValue(IsDropdownOpenProperty, true);
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Tab)
+        {
+            if(_endTextBox?.IsFocused == true)
+            {
+                SetCurrentValue(IsDropdownOpenProperty, false);
+            }
+            return;
+        }
+
+        base.OnKeyDown(e);
+    }
     
 }

--- a/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
@@ -434,30 +434,28 @@ public class DateRangePicker : DatePickerBase, IClearControl
     
     protected override void OnKeyDown(KeyEventArgs e)
     {
-        if (e.Key == Key.Escape)
+        switch (e.Key)
         {
-            SetCurrentValue(IsDropdownOpenProperty, false);
-            e.Handled = true;
-            return;
-        }
-
-        if (e.Key == Key.Down)
-        {
-            SetCurrentValue(IsDropdownOpenProperty, true);
-            e.Handled = true;
-            return;
-        }
-
-        if (e.Key == Key.Tab)
-        {
-            if(_endTextBox?.IsFocused == true)
-            {
+            case Key.Escape:
                 SetCurrentValue(IsDropdownOpenProperty, false);
+                e.Handled = true;
+                return;
+            case Key.Down:
+                SetCurrentValue(IsDropdownOpenProperty, true);
+                e.Handled = true;
+                return;
+            case Key.Tab:
+            {
+                if(_endTextBox?.IsFocused == true)
+                {
+                    SetCurrentValue(IsDropdownOpenProperty, false);
+                }
+                return;
             }
-            return;
+            default:
+                base.OnKeyDown(e);
+                break;
         }
-
-        base.OnKeyDown(e);
     }
     
 }


### PR DESCRIPTION
1. DatePicker popup was immediately closed when clicking on Month/Year switch. This is fixed. 
2. DateRangePicker could not be closed when tab out. This is fixed.