### PR TITLE
update-net8-target

### DIFF
--- a/src/Ursa.ReactiveUIExtension/Ursa.ReactiveUIExtension.csproj
+++ b/src/Ursa.ReactiveUIExtension/Ursa.ReactiveUIExtension.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <LangVersion>latest</LangVersion>
         <Authors>WCKYWCKF, IRIHI Technology</Authors>


### PR DESCRIPTION
`net8` is not a standard target framework name which should not be used, update to the standard `net8.0`

![image](https://github.com/user-attachments/assets/66f69369-a714-4771-b858-2cfc76728a56)


https://github.com/dotnet/designs/blob/main/accepted/2020/net5/net5.md#what-about-net-10