### PR TITLE
update compile condition

### DIFF
--- a/src/Ursa/Controls/EnumSelector/EnumSelector.cs
+++ b/src/Ursa/Controls/EnumSelector/EnumSelector.cs
@@ -131,7 +131,7 @@ public class EnumSelector: TemplatedControl
     }
 
     // netstandard 2.0 does not support Enum.GetValuesAsUnderlyingType, which is used for native aot compilation
-#if NET8_0_OR_GREATER
+#if NET
     private List<EnumItemTuple> GenerateItemTuple()
     {
         if (EnumType is null) return new List<EnumItemTuple>();

--- a/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
+++ b/src/Ursa/Controls/NumericUpDown/NumericUpDownBase.cs
@@ -367,7 +367,7 @@ public abstract class NumericUpDownBase<T> : NumericUpDown where T : struct, ICo
                 text = text.Substring(1);
             }
         }
-#if NET8_0_OR_GREATER
+#if NET
         else if ((numberStyles & NumberStyles.AllowBinarySpecifier) != 0)
         {
             if (text.StartsWith("0b") || text.StartsWith("0B")) // support 0b bin while user input


### PR DESCRIPTION
Since we're targeting for `netstandard2.0`/`net8.0`, update to `#if NET` to avoid changes in future target framework updates