### PR TITLE
Fixed: Closing a dialog returns TView to the user instead of occupying its parent.

### DIFF
--- a/tests/HeadlessTest.Ursa/Controls/OverlayShared/Case_Close_Dialog_Clear_Content_Parent/Test.cs
+++ b/tests/HeadlessTest.Ursa/Controls/OverlayShared/Case_Close_Dialog_Clear_Content_Parent/Test.cs
@@ -1,0 +1,27 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Threading;
+
+namespace HeadlessTest.Ursa.Controls.OverlayShared.Case_Close_Dialog_Clear_Content_Parent;
+
+public class Test
+{
+    [AvaloniaFact]
+    public void Dialog_Parent_Is_Cleared_After_Close()
+    {
+        var ursaWindow = new TestWindow();
+        ursaWindow.Show();
+        var button = ursaWindow.FindControl<Button>("button"); 
+        ursaWindow.MouseDown(new Point(280, 400), MouseButton.Left);
+        ursaWindow.MouseUp(new Point(280, 400), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        var parent = ursaWindow.TextBox.Parent;
+        Assert.NotNull(ursaWindow.TextBox.Parent);
+        ursaWindow.DialogViewModel.Close();
+        Dispatcher.UIThread.RunJobs();
+        Assert.Null(ursaWindow.TextBox.Parent);
+    }
+}

--- a/tests/HeadlessTest.Ursa/Controls/OverlayShared/Case_Close_Dialog_Clear_Content_Parent/TestWindow.axaml
+++ b/tests/HeadlessTest.Ursa/Controls/OverlayShared/Case_Close_Dialog_Clear_Content_Parent/TestWindow.axaml
@@ -1,0 +1,11 @@
+<u:UrsaWindow xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:u="https://irihi.tech/ursa"
+        mc:Ignorable="d" d:DesignWidth="800"
+        d:DesignHeight="450"
+        x:Class="HeadlessTest.Ursa.Controls.OverlayShared.Case_Close_Dialog_Clear_Content_Parent.TestWindow"
+        Title="TestWindow">
+    <Button HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Name="button" Content="Click" Click="Button_OnClick"></Button>
+</u:UrsaWindow>

--- a/tests/HeadlessTest.Ursa/Controls/OverlayShared/Case_Close_Dialog_Clear_Content_Parent/TestWindow.axaml.cs
+++ b/tests/HeadlessTest.Ursa/Controls/OverlayShared/Case_Close_Dialog_Clear_Content_Parent/TestWindow.axaml.cs
@@ -1,0 +1,32 @@
+using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Irihi.Avalonia.Shared.Contracts;
+using Ursa.Controls;
+
+namespace HeadlessTest.Ursa.Controls.OverlayShared.Case_Close_Dialog_Clear_Content_Parent;
+
+public partial class TestWindow : UrsaWindow
+{
+    public TestWindow()
+    {
+        InitializeComponent();
+    }
+
+    internal TextBox TextBox = new TextBox();
+    internal DialogViewModel DialogViewModel = new DialogViewModel();
+    
+    private void Button_OnClick(object? sender, RoutedEventArgs e)
+    {
+        OverlayDialog.Show(TextBox, DialogViewModel);
+    }
+}
+
+class DialogViewModel : IDialogContext
+{
+    public void Close()
+    {
+        RequestClose?.Invoke(this, null);
+    }
+
+    public event EventHandler<object?>? RequestClose;
+}


### PR DESCRIPTION
TView should be returned to the user instead of its parent after the dialog is closed.