### PR TITLE
Accessibility suppport for MultiComboItem

### DIFF
--- a/src/Ursa/Controls/ComboBox/MultiComboBoxItem.cs
+++ b/src/Ursa/Controls/ComboBox/MultiComboBoxItem.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia;
+using Avalonia.Automation.Peers;
 using Avalonia.Controls;
 using Avalonia.Controls.Mixins;
 using Avalonia.Input;
@@ -111,5 +112,9 @@ public class MultiComboBoxItem: ContentControl
             IsSelected =  _parent?.SelectedItems?.Contains(DataContext) ?? false;
         }
         _updateInternal = false;
+    }
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new ListItemAutomationPeer(this);
     }
 }


### PR DESCRIPTION
Current behavior
![1730772460562_FCABABBE-0C05-424c-8D77-0D82585024CD](https://github.com/user-attachments/assets/f635c443-f2bc-4fb6-8ad7-485d6e4f1ffb)

The items of mutiselectcombo can not be accessed by UIAutomation.