### PR TITLE
Feat: add a new control PathPicker, add PathPickerDemo

### DIFF
--- a/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
+++ b/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
@@ -13,7 +13,7 @@
             <StackPanel>
                 <HeaderedContentControl Theme="{DynamicResource GroupBox}"
                                         Header="Functionality and Usage"
-                                        Content="PathPicker aggregates file selection functionality and provides a Command property. When a button is pressed or Enter is pressed while the focus is on PathPicker, the Command is triggered and a Task &lt;IReadOnlyList&gt; is passed to the Command.">
+                                        Content="PathPicker aggregates a file selector and provides a Command property. The Command is triggered solely after opening the file selector and selecting a file, whereupon the Command receives an IReadOnlyList&lt;string&gt; parameter.">
                 </HeaderedContentControl>
                 <u:Form LabelAlignment="Left" LabelPosition="Left" LabelWidth="*" HorizontalAlignment="Stretch">
                     <TextBox Name="Title" u:FormItem.Label="Title"></TextBox>
@@ -24,7 +24,7 @@
                              Watermark="D:\Win7 Help\win-x64">
                     </TextBox>
                     <TextBox Name="FileFilter" u:FormItem.Label="FileFilter"
-                             Watermark="*.txt,*.json or *.json">
+                             Watermark="[Name,Pattern] like this [123,*.exe,*.pdb] or [All][ImageAll][11,*.txt]">
                     </TextBox>
                     <TextBox Name="DefaultFileExtension" u:FormItem.Label="DefaultFileExtension"
                              Watermark="json">
@@ -46,7 +46,20 @@
                                   DefaultFileExtension="{Binding #DefaultFileExtension.Text}"
                                   AllowMultiple="{Binding #AllowMultiple.IsChecked}"
                                   UsePickerType="{Binding #UsePickerType.Value}"
-                                  SelectedPath="{Binding Path,Mode=OneWayToSource}"
+                                  SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
+                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
+                    </u:PathPicker>
+                </HeaderedContentControl>
+                <HeaderedContentControl Header="PathPickerForMultipleText">
+                    <u:PathPicker Title="{Binding #Title.Text}"
+                                  Theme="{DynamicResource PathPickerForMultipleText}"
+                                  SuggestedFileName="{Binding #SuggestedFileName.Text}"
+                                  SuggestedStartPath="{Binding #SuggestedStartPath.Text}"
+                                  FileFilter="{Binding #FileFilter.Text}"
+                                  DefaultFileExtension="{Binding #DefaultFileExtension.Text}"
+                                  AllowMultiple="{Binding #AllowMultiple.IsChecked}"
+                                  UsePickerType="{Binding #UsePickerType.Value}"
+                                  SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
                                   SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
                     </u:PathPicker>
                 </HeaderedContentControl>
@@ -59,11 +72,11 @@
                                   DefaultFileExtension="{Binding #DefaultFileExtension.Text}"
                                   AllowMultiple="{Binding #AllowMultiple.IsChecked}"
                                   UsePickerType="{Binding #UsePickerType.Value}"
-                                  SelectedPath="{Binding Path,Mode=OneWayToSource}"
+                                  SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
                                   SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
                     </u:PathPicker>
                 </HeaderedContentControl>
-                <HeaderedContentControl Header="PathPickerForList">
+                <HeaderedContentControl Header="PathPickerForListView">
                     <u:PathPicker Theme="{DynamicResource PathPickerForList}"
                                   Title="{Binding #Title.Text}"
                                   SuggestedFileName="{Binding #SuggestedFileName.Text}"
@@ -72,7 +85,7 @@
                                   DefaultFileExtension="{Binding #DefaultFileExtension.Text}"
                                   AllowMultiple="{Binding #AllowMultiple.IsChecked}"
                                   UsePickerType="{Binding #UsePickerType.Value}"
-                                  SelectedPath="{Binding Path,Mode=OneWayToSource}"
+                                  SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
                                   SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
                     </u:PathPicker>
                 </HeaderedContentControl>
@@ -80,7 +93,7 @@
         </ScrollViewer>
         <ScrollViewer Grid.Column="1" Grid.Row="0" Grid.RowSpan="2">
             <StackPanel Spacing="1">
-                <HeaderedContentControl Header="SelectedPath">
+                <HeaderedContentControl Header="SelectedPathsText">
                     <TextBox Name="SelectedPath" u:FormItem.Label="SelectedPath" IsReadOnly="True"
                              Text="{Binding Path}">
                     </TextBox>

--- a/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
+++ b/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
@@ -1,23 +1,12 @@
-<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:vm="using:Sandbox.ViewModels"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:u="https://irihi.tech/ursa"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-        x:Class="Sandbox.Views.MainWindow"
-        x:DataType="vm:MainWindowViewModel"
-        xmlns:sys="using:System"
-        Icon="/Assets/avalonia-logo.ico"
-        Title="Sandbox">
-
-    <Design.DataContext>
-        <!-- This only sets the DataContext for the previewer in an IDE,
-             to set the actual DataContext for runtime, set the DataContext property in code (look at App.axaml.cs) -->
-        <vm:MainWindowViewModel />
-    </Design.DataContext>
-
-
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:u="https://irihi.tech/ursa"
+             xmlns:vm="using:Ursa.Demo.ViewModels"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="Ursa.Demo.Pages.PathPickerDemo"
+             x:DataType="vm:PathPickerDemoViewModel">
     <Grid ColumnDefinitions="*,*"
           RowDefinitions="7*,3*">
         <ScrollViewer Grid.Column="0" Grid.Row="0">
@@ -36,38 +25,41 @@
         <ScrollViewer Grid.Column="0" Grid.Row="1">
             <StackPanel Spacing="2">
                 <HeaderedContentControl Header="Default">
-                    <u:PathPicker Name="PathPicker"
-                                  Title="{Binding #Title.Text}"
+                    <u:PathPicker Title="{Binding #Title.Text}"
                                   SuggestedFileName="{Binding #SuggestedFileName.Text}"
                                   SuggestedStartPath="{Binding #SuggestedStartPath.Text}"
                                   FileFilter="{Binding #FileFilter.Text}"
                                   DefaultFileExtension="{Binding #DefaultFileExtension.Text}"
                                   AllowMultiple="{Binding #AllowMultiple.IsChecked}"
-                                  UsePickerType="{Binding #UsePickerType.Value}">
+                                  UsePickerType="{Binding #UsePickerType.Value}"
+                                  SelectedPath="{Binding Path,Mode=OneWayToSource}"
+                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
                     </u:PathPicker>
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="PathPickerOnlyButton">
-                    <u:PathPicker Name="PathPicker1"
-                                  Theme="{DynamicResource PathPickerOnlyButton}"
+                    <u:PathPicker Theme="{DynamicResource PathPickerOnlyButton}"
                                   Title="{Binding #Title.Text}"
                                   SuggestedFileName="{Binding #SuggestedFileName.Text}"
                                   SuggestedStartPath="{Binding #SuggestedStartPath.Text}"
                                   FileFilter="{Binding #FileFilter.Text}"
                                   DefaultFileExtension="{Binding #DefaultFileExtension.Text}"
                                   AllowMultiple="{Binding #AllowMultiple.IsChecked}"
-                                  UsePickerType="{Binding #UsePickerType.Value}">
+                                  UsePickerType="{Binding #UsePickerType.Value}"
+                                  SelectedPath="{Binding Path,Mode=OneWayToSource}"
+                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
                     </u:PathPicker>
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="PathPickerForList">
-                    <u:PathPicker Name="PathPicker2"
-                                  Theme="{DynamicResource PathPickerForList}"
+                    <u:PathPicker Theme="{DynamicResource PathPickerForList}"
                                   Title="{Binding #Title.Text}"
                                   SuggestedFileName="{Binding #SuggestedFileName.Text}"
                                   SuggestedStartPath="{Binding #SuggestedStartPath.Text}"
                                   FileFilter="{Binding #FileFilter.Text}"
                                   DefaultFileExtension="{Binding #DefaultFileExtension.Text}"
                                   AllowMultiple="{Binding #AllowMultiple.IsChecked}"
-                                  UsePickerType="{Binding #UsePickerType.Value}">
+                                  UsePickerType="{Binding #UsePickerType.Value}"
+                                  SelectedPath="{Binding Path,Mode=OneWayToSource}"
+                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
                     </u:PathPicker>
                 </HeaderedContentControl>
             </StackPanel>
@@ -76,15 +68,15 @@
             <StackPanel Spacing="1">
                 <HeaderedContentControl Header="SelectedPath">
                     <TextBox Name="SelectedPath" u:FormItem.Label="SelectedPath" IsReadOnly="True"
-                             Text="{Binding #PathPicker.SelectedPath}">
+                             Text="{Binding Path}">
                     </TextBox>
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="SelectedPaths">
                     <ListBox Name="SelectedPaths"
-                             ItemsSource="{Binding #PathPicker.SelectedPaths}">
+                             ItemsSource="{Binding Paths}">
                     </ListBox>
                 </HeaderedContentControl>
             </StackPanel>
         </ScrollViewer>
     </Grid>
-</Window>
+</UserControl>

--- a/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
+++ b/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
@@ -32,6 +32,10 @@
                     <ToggleButton Name="AllowMultiple" Content="AllowMultiple" u:FormItem.NoLabel="True"
                                   HorizontalAlignment="Stretch">
                     </ToggleButton>
+                    <ToggleButton Name="IsCancelingPickerAlsoTriggers" Content="Canceling selection also triggers the Command."
+                                  u:FormItem.NoLabel="True"
+                                  HorizontalAlignment="Stretch">
+                    </ToggleButton>
                     <u:EnumSelector Name="UsePickerType" EnumType="u:UsePickerTypes" u:FormItem.Label="UsePickerType"></u:EnumSelector>
                 </u:Form>
             </StackPanel>
@@ -47,20 +51,9 @@
                                   AllowMultiple="{Binding #AllowMultiple.IsChecked}"
                                   UsePickerType="{Binding #UsePickerType.Value}"
                                   SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
-                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
-                    </u:PathPicker>
-                </HeaderedContentControl>
-                <HeaderedContentControl Header="PathPickerForMultipleText">
-                    <u:PathPicker Title="{Binding #Title.Text}"
-                                  Theme="{DynamicResource PathPickerForMultipleText}"
-                                  SuggestedFileName="{Binding #SuggestedFileName.Text}"
-                                  SuggestedStartPath="{Binding #SuggestedStartPath.Text}"
-                                  FileFilter="{Binding #FileFilter.Text}"
-                                  DefaultFileExtension="{Binding #DefaultFileExtension.Text}"
-                                  AllowMultiple="{Binding #AllowMultiple.IsChecked}"
-                                  UsePickerType="{Binding #UsePickerType.Value}"
-                                  SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
-                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
+                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}"
+                                  Command="{Binding SelectedCommand}"
+                                  IsCancelingPickerAlsoTriggers="{Binding #IsCancelingPickerAlsoTriggers.IsChecked}">
                     </u:PathPicker>
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="PathPickerOnlyButton">
@@ -73,11 +66,13 @@
                                   AllowMultiple="{Binding #AllowMultiple.IsChecked}"
                                   UsePickerType="{Binding #UsePickerType.Value}"
                                   SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
-                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
+                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}"
+                                  Command="{Binding SelectedCommand}"
+                                  IsCancelingPickerAlsoTriggers="{Binding #IsCancelingPickerAlsoTriggers.IsChecked}">
                     </u:PathPicker>
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="PathPickerForListView">
-                    <u:PathPicker Theme="{DynamicResource PathPickerForList}"
+                    <u:PathPicker Theme="{DynamicResource PathPickerForListView}"
                                   Title="{Binding #Title.Text}"
                                   SuggestedFileName="{Binding #SuggestedFileName.Text}"
                                   SuggestedStartPath="{Binding #SuggestedStartPath.Text}"
@@ -86,13 +81,16 @@
                                   AllowMultiple="{Binding #AllowMultiple.IsChecked}"
                                   UsePickerType="{Binding #UsePickerType.Value}"
                                   SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
-                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}">
+                                  SelectedPaths="{Binding Paths,Mode=OneWayToSource}"
+                                  Command="{Binding SelectedCommand}"
+                                  IsCancelingPickerAlsoTriggers="{Binding #IsCancelingPickerAlsoTriggers.IsChecked}">
                     </u:PathPicker>
                 </HeaderedContentControl>
             </StackPanel>
         </ScrollViewer>
         <ScrollViewer Grid.Column="1" Grid.Row="0" Grid.RowSpan="2">
             <StackPanel Spacing="1">
+                <TextBlock Text="{Binding CommandTriggerCount,StringFormat='Command Trigger Count:{0}'}"></TextBlock>
                 <HeaderedContentControl Header="SelectedPathsText">
                     <TextBox Name="SelectedPath" u:FormItem.Label="SelectedPath" IsReadOnly="True"
                              Text="{Binding Path}">

--- a/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
+++ b/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
@@ -32,7 +32,11 @@
                     <ToggleButton Name="AllowMultiple" Content="AllowMultiple" u:FormItem.NoLabel="True"
                                   HorizontalAlignment="Stretch">
                     </ToggleButton>
-                    <ToggleButton Name="IsCancelingPickerAlsoTriggers" Content="Canceling selection also triggers the Command."
+                    <ToggleButton Name="IsOmitCommandOnCancel" Content="Do not trigger the command after unselecting."
+                                  u:FormItem.NoLabel="True"
+                                  HorizontalAlignment="Stretch">
+                    </ToggleButton>
+                    <ToggleButton Name="IsClearSelectionOnCancel" Content="Clear the selection when unselecting."
                                   u:FormItem.NoLabel="True"
                                   HorizontalAlignment="Stretch">
                     </ToggleButton>
@@ -53,7 +57,8 @@
                                   SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
                                   SelectedPaths="{Binding Paths,Mode=OneWayToSource}"
                                   Command="{Binding SelectedCommand}"
-                                  IsCancelingPickerAlsoTriggers="{Binding #IsCancelingPickerAlsoTriggers.IsChecked}">
+                                  IsOmitCommandOnCancel="{Binding #IsOmitCommandOnCancel.IsChecked}"
+                                  IsClearSelectionOnCancel="{Binding #IsClearSelectionOnCancel.IsChecked}">
                     </u:PathPicker>
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="PathPickerOnlyButton">
@@ -68,7 +73,8 @@
                                   SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
                                   SelectedPaths="{Binding Paths,Mode=OneWayToSource}"
                                   Command="{Binding SelectedCommand}"
-                                  IsCancelingPickerAlsoTriggers="{Binding #IsCancelingPickerAlsoTriggers.IsChecked}">
+                                  IsOmitCommandOnCancel="{Binding #IsOmitCommandOnCancel.IsChecked}"
+                                  IsClearSelectionOnCancel="{Binding #IsClearSelectionOnCancel.IsChecked}">
                     </u:PathPicker>
                 </HeaderedContentControl>
                 <HeaderedContentControl Header="PathPickerForListView">
@@ -83,7 +89,8 @@
                                   SelectedPathsText="{Binding Path,Mode=OneWayToSource}"
                                   SelectedPaths="{Binding Paths,Mode=OneWayToSource}"
                                   Command="{Binding SelectedCommand}"
-                                  IsCancelingPickerAlsoTriggers="{Binding #IsCancelingPickerAlsoTriggers.IsChecked}">
+                                  IsOmitCommandOnCancel="{Binding #IsOmitCommandOnCancel.IsChecked}"
+                                  IsClearSelectionOnCancel="{Binding #IsClearSelectionOnCancel.IsChecked}">
                     </u:PathPicker>
                 </HeaderedContentControl>
             </StackPanel>

--- a/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
+++ b/demo/Ursa.Demo/Pages/PathPickerDemo.axaml
@@ -10,17 +10,31 @@
     <Grid ColumnDefinitions="*,*"
           RowDefinitions="7*,3*">
         <ScrollViewer Grid.Column="0" Grid.Row="0">
-            <u:Form LabelAlignment="Left" LabelPosition="Left" LabelWidth="*" HorizontalAlignment="Stretch">
-                <TextBox Name="Title" u:FormItem.Label="Title"></TextBox>
-                <TextBox Name="SuggestedFileName" u:FormItem.Label="SuggestedFileName"></TextBox>
-                <TextBox Name="SuggestedStartPath" u:FormItem.Label="SuggestedStartPath"></TextBox>
-                <TextBox Name="FileFilter" u:FormItem.Label="FileFilter"></TextBox>
-                <TextBox Name="DefaultFileExtension" u:FormItem.Label="DefaultFileExtension"></TextBox>
-                <ToggleButton Name="AllowMultiple" Content="AllowMultiple" u:FormItem.NoLabel="True"
-                              HorizontalAlignment="Stretch">
-                </ToggleButton>
-                <u:EnumSelector Name="UsePickerType" EnumType="u:UsePickerTypes" u:FormItem.Label="UsePickerType"></u:EnumSelector>
-            </u:Form>
+            <StackPanel>
+                <HeaderedContentControl Theme="{DynamicResource GroupBox}"
+                                        Header="Functionality and Usage"
+                                        Content="PathPicker aggregates file selection functionality and provides a Command property. When a button is pressed or Enter is pressed while the focus is on PathPicker, the Command is triggered and a Task &lt;IReadOnlyList&gt; is passed to the Command.">
+                </HeaderedContentControl>
+                <u:Form LabelAlignment="Left" LabelPosition="Left" LabelWidth="*" HorizontalAlignment="Stretch">
+                    <TextBox Name="Title" u:FormItem.Label="Title"></TextBox>
+                    <TextBox Name="SuggestedFileName" u:FormItem.Label="SuggestedFileName"
+                             Watermark="filename(not have file extension)">
+                    </TextBox>
+                    <TextBox Name="SuggestedStartPath" u:FormItem.Label="SuggestedStartPath"
+                             Watermark="D:\Win7 Help\win-x64">
+                    </TextBox>
+                    <TextBox Name="FileFilter" u:FormItem.Label="FileFilter"
+                             Watermark="*.txt,*.json or *.json">
+                    </TextBox>
+                    <TextBox Name="DefaultFileExtension" u:FormItem.Label="DefaultFileExtension"
+                             Watermark="json">
+                    </TextBox>
+                    <ToggleButton Name="AllowMultiple" Content="AllowMultiple" u:FormItem.NoLabel="True"
+                                  HorizontalAlignment="Stretch">
+                    </ToggleButton>
+                    <u:EnumSelector Name="UsePickerType" EnumType="u:UsePickerTypes" u:FormItem.Label="UsePickerType"></u:EnumSelector>
+                </u:Form>
+            </StackPanel>
         </ScrollViewer>
         <ScrollViewer Grid.Column="0" Grid.Row="1">
             <StackPanel Spacing="2">

--- a/demo/Ursa.Demo/Pages/PathPickerDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/PathPickerDemo.axaml.cs
@@ -1,0 +1,13 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace Ursa.Demo.Pages;
+
+public partial class PathPickerDemo : UserControl
+{
+    public PathPickerDemo()
+    {
+        InitializeComponent();
+    }
+}

--- a/demo/Ursa.Demo/ViewModels/MainViewViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/MainViewViewModel.cs
@@ -4,6 +4,7 @@ using Avalonia;
 using Avalonia.Styling;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
+using Ursa.Controls;
 using Ursa.Themes.Semi;
 
 namespace Ursa.Demo.ViewModels;
@@ -79,6 +80,7 @@ public partial class MainViewViewModel : ViewModelBase
             MenuKeys.MenuKeyTreeComboBox => new TreeComboBoxDemoViewModel(),
             MenuKeys.MenuKeyTwoTonePathIcon => new TwoTonePathIconDemoViewModel(),
             MenuKeys.AspectRatioLayout => new AspectRatioLayoutDemoViewModel(),
+            MenuKeys.PathPicker => new PathPickerDemoViewModel(),
             _ => throw new ArgumentOutOfRangeException(nameof(s), s, null)
         };
     }

--- a/demo/Ursa.Demo/ViewModels/MenuViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/MenuViewModel.cs
@@ -59,7 +59,8 @@ public class MenuViewModel : ViewModelBase
             new() { MenuHeader = "ToolBar", Key = MenuKeys.MenuKeyToolBar },
             new() { MenuHeader = "TreeComboBox", Key = MenuKeys.MenuKeyTreeComboBox },
             new() { MenuHeader = "TwoTonePathIcon", Key = MenuKeys.MenuKeyTwoTonePathIcon },
-            new() { MenuHeader = "AspectRatioLayout", Key = MenuKeys.AspectRatioLayout ,Status = "WIP"},
+            new() { MenuHeader = "AspectRatioLayout", Key = MenuKeys.AspectRatioLayout, Status = "New" },
+            new() { MenuHeader = "PathPicker", Key = MenuKeys.PathPicker, Status = "WIP" },
         };
     }
 }
@@ -115,4 +116,5 @@ public static class MenuKeys
     public const string MenuKeyTreeComboBox = "TreeComboBox";
     public const string MenuKeyTwoTonePathIcon = "TwoTonePathIcon";
     public const string AspectRatioLayout = "AspectRatioLayout";
+    public const string PathPicker = "PathPicker";
 }

--- a/demo/Ursa.Demo/ViewModels/PathPickerDemoViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/PathPickerDemoViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 
 namespace Ursa.Demo.ViewModels;
 
@@ -7,4 +8,11 @@ public partial class PathPickerDemoViewModel : ViewModelBase
 {
     [ObservableProperty] private string? _path;
     [ObservableProperty] private IReadOnlyList<string>? _paths;
+    [ObservableProperty] private int _commandTriggerCount = 0;
+
+    [RelayCommand]
+    private void Selected(IReadOnlyList<string> paths)
+    {
+        CommandTriggerCount++;
+    }
 }

--- a/demo/Ursa.Demo/ViewModels/PathPickerDemoViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/PathPickerDemoViewModel.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace Ursa.Demo.ViewModels;
+
+public partial class PathPickerDemoViewModel : ViewModelBase
+{
+    [ObservableProperty] private string? _path;
+    [ObservableProperty] private IReadOnlyList<string>? _paths;
+}

--- a/src/Ursa.ReactiveUIExtension/Ursa.ReactiveUIExtension.csproj
+++ b/src/Ursa.ReactiveUIExtension/Ursa.ReactiveUIExtension.csproj
@@ -14,14 +14,14 @@
 
             这个是一个Ursa拓展包。这个包整合并互相兼容了UrsaWindow和UrsaView与Avalonia.ReactiveUI的功能。【Avalonia.ReactiveUI参见：https://docs.avaloniaui.net/docs/concepts/reactiveui/】
         </Description>
-        <Version>1.0.1</Version>
+        <Version>1.0.2</Version>
         <RepositoryUrl>https://github.com/irihitech/Ursa.Avalonia</RepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.ReactiveUI" Version="11.1.1"/>
+        <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ursa.Themes.Semi/Controls/PathPicker.axaml
+++ b/src/Ursa.Themes.Semi/Controls/PathPicker.axaml
@@ -11,32 +11,31 @@
                             Content="{TemplateBinding Title}"
                             Margin="1,0,0,0">
                     </Button>
-                    <TextBox DockPanel.Dock="Left"
+                    <TextBox Name="PART_TextBox"
+                             DockPanel.Dock="Left"
+                             AcceptsReturn="{TemplateBinding AllowMultiple}"
                              Text="{TemplateBinding SelectedPathsText,Mode=TwoWay}">
                     </TextBox>
                 </DockPanel>
             </ControlTemplate>
         </Setter>
-    </ControlTheme>
 
-    <ControlTheme x:Key="PathPickerForMultipleText" TargetType="ursa:PathPicker">
-        <Setter Property="Template">
-            <ControlTemplate>
-                <DockPanel HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                           VerticalAlignment="{TemplateBinding VerticalAlignment}">
-                    <Button Name="PART_Button"
-                            DockPanel.Dock="Top"
-                            HorizontalAlignment="Stretch"
-                            Content="{TemplateBinding Title}"
-                            Margin="0,0,0,1">
-                    </Button>
-                    <TextBox DockPanel.Dock="Bottom"
-                             Text="{TemplateBinding SelectedPathsText,Mode=TwoWay}"
-                             AcceptsReturn="True">
-                    </TextBox>
-                </DockPanel>
-            </ControlTemplate>
-        </Setter>
+        <Style Selector="^[AllowMultiple=False]">
+            <Style Selector="^ /template/ Button#PART_Button">
+                <Setter Property="DockPanel.Dock" Value="Right"></Setter>
+            </Style>
+            <Style Selector="^ /template/ TextBox#PART_TextBox">
+                <Setter Property="DockPanel.Dock" Value="Left"></Setter>
+            </Style>
+        </Style>
+        <Style Selector="^[AllowMultiple=True]">
+            <Style Selector="^ /template/ Button#PART_Button">
+                <Setter Property="DockPanel.Dock" Value="Top"></Setter>
+            </Style>
+            <Style Selector="^ /template/ TextBox#PART_TextBox">
+                <Setter Property="DockPanel.Dock" Value="Bottom"></Setter>
+            </Style>
+        </Style>
     </ControlTheme>
 
 

--- a/src/Ursa.Themes.Semi/Controls/PathPicker.axaml
+++ b/src/Ursa.Themes.Semi/Controls/PathPicker.axaml
@@ -9,16 +9,36 @@
                     <Button Name="PART_Button"
                             DockPanel.Dock="Right"
                             Content="{TemplateBinding Title}"
-                            Command="{TemplateBinding Command}"
                             Margin="1,0,0,0">
                     </Button>
                     <TextBox DockPanel.Dock="Left"
-                             Text="{TemplateBinding SelectedPath,Mode=TwoWay}">
+                             Text="{TemplateBinding SelectedPathsText,Mode=TwoWay}">
                     </TextBox>
                 </DockPanel>
             </ControlTemplate>
         </Setter>
     </ControlTheme>
+
+    <ControlTheme x:Key="PathPickerForMultipleText" TargetType="ursa:PathPicker">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DockPanel HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                           VerticalAlignment="{TemplateBinding VerticalAlignment}">
+                    <Button Name="PART_Button"
+                            DockPanel.Dock="Top"
+                            HorizontalAlignment="Stretch"
+                            Content="{TemplateBinding Title}"
+                            Margin="0,0,0,1">
+                    </Button>
+                    <TextBox DockPanel.Dock="Bottom"
+                             Text="{TemplateBinding SelectedPathsText,Mode=TwoWay}"
+                             AcceptsReturn="True">
+                    </TextBox>
+                </DockPanel>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+
 
     <ControlTheme x:Key="PathPickerOnlyButton" TargetType="ursa:PathPicker">
         <Setter Property="Template">
@@ -26,14 +46,13 @@
                 <Button Name="PART_Button"
                         HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                         VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                        Content="{TemplateBinding Title}"
-                        Command="{TemplateBinding Command}">
+                        Content="{TemplateBinding Title}">
                 </Button>
             </ControlTemplate>
         </Setter>
     </ControlTheme>
 
-    <ControlTheme x:Key="PathPickerForList" TargetType="ursa:PathPicker">
+    <ControlTheme x:Key="PathPickerForListView" TargetType="ursa:PathPicker">
         <Setter Property="Template">
             <ControlTemplate>
                 <Expander HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
@@ -41,8 +60,7 @@
                     <Expander.Header>
                         <Button Name="PART_Button"
                                 HorizontalAlignment="Stretch"
-                                Content="{TemplateBinding Title}"
-                                Command="{TemplateBinding Command}">
+                                Content="{TemplateBinding Title}">
                             <Button.Theme>
                                 <ControlTheme TargetType="Button">
                                     <Setter Property="Template">

--- a/src/Ursa.Themes.Semi/Controls/PathPicker.axaml
+++ b/src/Ursa.Themes.Semi/Controls/PathPicker.axaml
@@ -1,0 +1,66 @@
+﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:ursa="https://irihi.tech/ursa">
+    <ControlTheme x:Key="{x:Type ursa:PathPicker}" TargetType="ursa:PathPicker">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DockPanel HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                           VerticalAlignment="{TemplateBinding VerticalAlignment}">
+                    <Button Name="PART_Button"
+                            DockPanel.Dock="Right"
+                            Content="{TemplateBinding Title}"
+                            Command="{TemplateBinding Command}"
+                            Margin="1,0,0,0">
+                    </Button>
+                    <TextBox DockPanel.Dock="Left"
+                             Text="{TemplateBinding SelectedPath,Mode=TwoWay}">
+                    </TextBox>
+                </DockPanel>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+
+    <ControlTheme x:Key="PathPickerOnlyButton" TargetType="ursa:PathPicker">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Button Name="PART_Button"
+                        HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                        VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                        Content="{TemplateBinding Title}"
+                        Command="{TemplateBinding Command}">
+                </Button>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+
+    <ControlTheme x:Key="PathPickerForList" TargetType="ursa:PathPicker">
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Expander HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                          VerticalAlignment="{TemplateBinding VerticalAlignment}">
+                    <Expander.Header>
+                        <Button Name="PART_Button"
+                                HorizontalAlignment="Stretch"
+                                Content="{TemplateBinding Title}"
+                                Command="{TemplateBinding Command}">
+                            <Button.Theme>
+                                <ControlTheme TargetType="Button">
+                                    <Setter Property="Template">
+                                        <ControlTemplate>
+                                            <TextPresenter Text="{TemplateBinding Content}"
+                                                           Background="Transparent"
+                                                           HorizontalAlignment="Stretch"
+                                                           VerticalAlignment="Stretch">
+                                            </TextPresenter>
+                                        </ControlTemplate>
+                                    </Setter>
+                                </ControlTheme>
+                            </Button.Theme>
+                        </Button>
+                    </Expander.Header>
+                    <ListBox ItemsSource="{TemplateBinding SelectedPaths}"></ListBox>
+                </Expander>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Controls/_index.axaml
+++ b/src/Ursa.Themes.Semi/Controls/_index.axaml
@@ -55,5 +55,6 @@
         <ResourceInclude Source="UrsaView.axaml" />
         <ResourceInclude Source="UrsaWindow.axaml"/>
         <ResourceInclude Source="PinCode.axaml" />
+        <ResourceInclude Source="PathPicker.axaml"/>
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/Ursa/Controls/PathPicker/PathPicker.cs
+++ b/src/Ursa/Controls/PathPicker/PathPicker.cs
@@ -139,10 +139,13 @@ public class PathPicker : TemplatedControl
         {
             _twoConvertLock = true;
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append(SelectedPaths[0]);
-            foreach (var item in SelectedPaths.Skip(1))
+            if (SelectedPaths.Count != 0)
             {
-                stringBuilder.AppendLine(item);
+                stringBuilder.Append(SelectedPaths[0]);
+                foreach (var item in SelectedPaths.Skip(1))
+                {
+                    stringBuilder.AppendLine(item);
+                }
             }
 
             SelectedPathsText = stringBuilder.ToString();

--- a/src/Ursa/Controls/PathPicker/PathPicker.cs
+++ b/src/Ursa/Controls/PathPicker/PathPicker.cs
@@ -1,0 +1,211 @@
+﻿using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Metadata;
+using Avalonia.Controls.Primitives;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
+using Avalonia.Threading;
+using Irihi.Avalonia.Shared.Common;
+
+namespace Ursa.Controls;
+
+[TemplatePart(Name = "PART_Button", Type = typeof(Button))]
+public class PathPicker : TemplatedControl
+{
+    public static readonly StyledProperty<string?> SelectedPathProperty =
+        AvaloniaProperty.Register<PathPicker, string?>(
+            nameof(SelectedPath), defaultBindingMode: BindingMode.TwoWay, enableDataValidation: true,
+            validate: x => string.IsNullOrWhiteSpace(x) || File.Exists(x) || Directory.Exists(x));
+
+
+    public static readonly StyledProperty<string> SuggestedStartPathProperty =
+        AvaloniaProperty.Register<PathPicker, string>(
+            nameof(SuggestedStartPath), string.Empty);
+
+    public static readonly StyledProperty<UsePickerTypes> UsePickerTypeProperty =
+        AvaloniaProperty.Register<PathPicker, UsePickerTypes>(
+            nameof(UsePickerType));
+
+    public static readonly StyledProperty<string> SuggestedFileNameProperty =
+        AvaloniaProperty.Register<PathPicker, string>(
+            nameof(SuggestedFileName), string.Empty);
+
+    public static readonly StyledProperty<string> FileFilterProperty = AvaloniaProperty.Register<PathPicker, string>(
+        nameof(FileFilter), string.Empty);
+
+    public static readonly StyledProperty<string> TitleProperty = AvaloniaProperty.Register<PathPicker, string>(
+        nameof(Title), string.Empty);
+
+    public static readonly StyledProperty<string> DefaultFileExtensionProperty =
+        AvaloniaProperty.Register<PathPicker, string>(
+            nameof(DefaultFileExtension), string.Empty);
+
+    public static readonly DirectProperty<PathPicker, IReadOnlyList<string>> SelectedPathsProperty =
+        AvaloniaProperty.RegisterDirect<PathPicker, IReadOnlyList<string>>(
+            nameof(SelectedPaths), o => o.SelectedPaths, (o, v) => o.SelectedPaths = v);
+
+    public static readonly StyledProperty<ICommand?> CommandProperty = AvaloniaProperty.Register<PathPicker, ICommand?>(
+        nameof(Command));
+
+    public static readonly StyledProperty<bool> AllowMultipleProperty = AvaloniaProperty.Register<PathPicker, bool>(
+        nameof(AllowMultiple));
+
+    private Button? _button;
+
+    private IReadOnlyList<string> _selectedPaths = [];
+
+    public PathPicker()
+    {
+        KeyBindings.Add(new KeyBinding
+        {
+            Command = new IRIHI_CommandBase(() =>
+            {
+                if (!SelectedPathProperty.ValidateValue!.Invoke(SelectedPath)) return;
+                SelectedPaths = string.IsNullOrWhiteSpace(SelectedPath) ? Array.Empty<string>() : [SelectedPath!];
+                Command?.Execute(Task.FromResult(SelectedPaths));
+            }),
+            Gesture = new KeyGesture(Key.Enter)
+        });
+    }
+
+    public bool AllowMultiple
+    {
+        get => GetValue(AllowMultipleProperty);
+        set => SetValue(AllowMultipleProperty, value);
+    }
+
+    public ICommand? Command
+    {
+        get => GetValue(CommandProperty);
+        set => SetValue(CommandProperty, value);
+    }
+
+    public IReadOnlyList<string> SelectedPaths
+    {
+        get => _selectedPaths;
+        private set => SetAndRaise(SelectedPathsProperty, ref _selectedPaths, value);
+    }
+
+    public string SuggestedFileName
+    {
+        get => GetValue(SuggestedFileNameProperty);
+        set => SetValue(SuggestedFileNameProperty, value);
+    }
+
+    public string DefaultFileExtension
+    {
+        get => GetValue(DefaultFileExtensionProperty);
+        set => SetValue(DefaultFileExtensionProperty, value);
+    }
+
+
+    public string Title
+    {
+        get => GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public string FileFilter
+    {
+        get => GetValue(FileFilterProperty);
+        set => SetValue(FileFilterProperty, value);
+    }
+
+    public UsePickerTypes UsePickerType
+    {
+        get => GetValue(UsePickerTypeProperty);
+        set => SetValue(UsePickerTypeProperty, value);
+    }
+
+    public string SuggestedStartPath
+    {
+        get => GetValue(SuggestedStartPathProperty);
+        set => SetValue(SuggestedStartPathProperty, value);
+    }
+
+    public string? SelectedPath
+    {
+        get => GetValue(SelectedPathProperty);
+        set => SetValue(SelectedPathProperty, value);
+    }
+
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == SelectedPathsProperty)
+            SelectedPath = SelectedPaths.Count > 0 ? SelectedPaths[0] : string.Empty;
+    }
+
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+        _button = e.NameScope.Find<Button>("PART_Button");
+        _button!.Click += LaunchPicker;
+    }
+
+    private void LaunchPicker(object? sender, RoutedEventArgs e)
+    {
+        if (TopLevel.GetTopLevel(this)?.StorageProvider is not { } storageProvider) return;
+
+        Task<IReadOnlyList<string>> task = Task.Run(async () =>
+        {
+            await Dispatcher.UIThread.InvokeAsync(async () =>
+            {
+                switch (UsePickerType)
+                {
+                    case UsePickerTypes.OpenFile:
+                        FilePickerOpenOptions filePickerOpenOptions = new()
+                        {
+                            Title = Title,
+                            AllowMultiple = AllowMultiple,
+                            SuggestedStartLocation =
+                                await storageProvider.TryGetFolderFromPathAsync(SuggestedStartPath),
+                            FileTypeFilter = FileFilter?.Split(',')
+                                .Select(x => new FilePickerFileType(x) { Patterns = [x] }).ToList()
+                        };
+                        var resFiles = await storageProvider.OpenFilePickerAsync(filePickerOpenOptions);
+                        SelectedPaths = resFiles.Select(x => x.TryGetLocalPath()).ToArray()!;
+                        break;
+                    case UsePickerTypes.SaveFile:
+                        FilePickerSaveOptions filePickerSaveOptions = new()
+                        {
+                            Title = Title,
+                            SuggestedStartLocation =
+                                await storageProvider.TryGetFolderFromPathAsync(SuggestedStartPath),
+                            SuggestedFileName = SuggestedFileName,
+                            FileTypeChoices = FileFilter?.Split(',')
+                                .Select(x => new FilePickerFileType(x) { Patterns = [x] }).ToList(),
+                            DefaultExtension = DefaultFileExtension
+                        };
+
+                        var path = (await storageProvider.SaveFilePickerAsync(filePickerSaveOptions))
+                            ?.TryGetLocalPath();
+                        SelectedPaths = string.IsNullOrEmpty(path)
+                            ? Array.Empty<string>()
+                            : [path!];
+                        break;
+                    case UsePickerTypes.OpenFolder:
+                        FolderPickerOpenOptions folderPickerOpenOptions = new()
+                        {
+                            Title = Title,
+                            AllowMultiple = AllowMultiple,
+                            SuggestedStartLocation =
+                                await storageProvider.TryGetFolderFromPathAsync(SuggestedStartPath),
+                            SuggestedFileName = SuggestedFileName
+                        };
+                        var resFolder = await storageProvider.OpenFolderPickerAsync(folderPickerOpenOptions);
+                        SelectedPaths = resFolder.Select(x => x.TryGetLocalPath()).ToArray()!;
+                        break;
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            });
+
+            return await Dispatcher.UIThread.InvokeAsync(() => SelectedPaths);
+        });
+        _button!.CommandParameter = task;
+    }
+}

--- a/src/Ursa/Controls/PathPicker/PathPicker.cs
+++ b/src/Ursa/Controls/PathPicker/PathPicker.cs
@@ -54,6 +54,16 @@ public class PathPicker : TemplatedControl
         AvaloniaProperty.Register<PathPicker, string?>(
             nameof(SelectedPathsText), defaultBindingMode: BindingMode.TwoWay);
 
+    public static readonly StyledProperty<bool> IsCancelingPickerAlsoTriggersProperty =
+        AvaloniaProperty.Register<PathPicker, bool>(
+            nameof(IsCancelingPickerAlsoTriggers));
+
+    public bool IsCancelingPickerAlsoTriggers
+    {
+        get => GetValue(IsCancelingPickerAlsoTriggersProperty);
+        set => SetValue(IsCancelingPickerAlsoTriggersProperty, value);
+    }
+
     public string? SelectedPathsText
     {
         get => GetValue(SelectedPathsTextProperty);
@@ -129,7 +139,7 @@ public class PathPicker : TemplatedControl
         {
             _twoConvertLock = true;
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append(SelectedPaths.FirstOrDefault());
+            stringBuilder.Append(SelectedPaths[0]);
             foreach (var item in SelectedPaths.Skip(1))
             {
                 stringBuilder.AppendLine(item);
@@ -268,7 +278,7 @@ public class PathPicker : TemplatedControl
                     throw new ArgumentOutOfRangeException();
             }
 
-            if (SelectedPaths.Count != 0)
+            if (SelectedPaths.Count != 0 || IsCancelingPickerAlsoTriggers)
                 Command?.Execute(SelectedPaths);
         }
         catch (Exception exception)

--- a/src/Ursa/Controls/PathPicker/UsePickerTypes.cs
+++ b/src/Ursa/Controls/PathPicker/UsePickerTypes.cs
@@ -1,0 +1,8 @@
+namespace Ursa.Controls;
+
+public enum UsePickerTypes
+{
+    OpenFile,
+    SaveFile,
+    OpenFolder
+}


### PR DESCRIPTION
`PathPicker` aggregates file selection functionality and provides a `Command` property. When a button is pressed or Enter is pressed while the focus is on `PathPicker`, the `Command `is triggered and a `Task<IReadOnlyList>` is passed to the `Command`.