### PR TITLE
Enable IME for IPv4Box on android. 

### DIFF
--- a/src/Ursa/Controls/IPv4Box/IPv4Box.cs
+++ b/src/Ursa/Controls/IPv4Box/IPv4Box.cs
@@ -281,6 +281,13 @@ public class IPv4Box: TemplatedControl
         {
             if (presenter?.Bounds.Contains(position)??false)
             {
+                _imClient.SetPresenter(presenter, this);
+                RaiseEvent(new TextInputMethodClientRequestedEventArgs()
+                {
+                    Source = presenter,
+                    Client = _imClient,
+                    RoutedEvent = InputElement.TextInputMethodClientRequestedEvent,
+                });
                 if (e.ClickCount == 1)
                 {
                     presenter.ShowCaret();

--- a/src/Ursa/Controls/IPv4Box/IPv4Box.cs
+++ b/src/Ursa/Controls/IPv4Box/IPv4Box.cs
@@ -281,15 +281,9 @@ public class IPv4Box: TemplatedControl
         {
             if (presenter?.Bounds.Contains(position)??false)
             {
-                _imClient.SetPresenter(presenter, this);
-                RaiseEvent(new TextInputMethodClientRequestedEventArgs()
-                {
-                    Source = presenter,
-                    Client = _imClient,
-                    RoutedEvent = InputElement.TextInputMethodClientRequestedEvent,
-                });
                 if (e.ClickCount == 1)
                 {
+                    _imClient.SetPresenter(presenter);
                     presenter.ShowCaret();
                     _currentActivePresenter = presenter;
                     var caretPosition = position.WithX(position.X - presenter.Bounds.X);

--- a/src/Ursa/Controls/IPv4Box/IPv4Box.cs
+++ b/src/Ursa/Controls/IPv4Box/IPv4Box.cs
@@ -7,6 +7,7 @@ using Avalonia.Controls.Primitives;
 using Avalonia.Data;
 using Avalonia.Input;
 using Avalonia.Input.Platform;
+using Avalonia.Input.TextInput;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Media.TextFormatting;
@@ -96,11 +97,15 @@ public class IPv4Box: TemplatedControl
         get => GetValue(InputModeProperty);
         set => SetValue(InputModeProperty, value);
     }
-
+    private readonly IPv4BoxInputMethodClient _imClient = new IPv4BoxInputMethodClient();
     static IPv4Box()
     {
         ShowLeadingZeroProperty.Changed.AddClassHandler<IPv4Box>((o, e) => o.OnFormatChange(e));
         IPAddressProperty.Changed.AddClassHandler<IPv4Box>((o, e) => o.OnIPChanged(e));
+        TextInputMethodClientRequestedEvent.AddClassHandler<IPv4Box>((tb, e) =>
+        {
+            e.Client = tb._imClient;
+        });
     }
     
     #region Overrides

--- a/src/Ursa/Controls/IPv4Box/IPv4BoxInputMethodClient.cs
+++ b/src/Ursa/Controls/IPv4Box/IPv4BoxInputMethodClient.cs
@@ -18,21 +18,8 @@ public class IPv4BoxInputMethodClient:TextInputMethodClient
     public override Rect CursorRectangle { get; }
     public override TextSelection Selection { get; set; }
     private IPv4Box? _parent;
-    public void SetPresenter(TextPresenter? presenter, IPv4Box? parent)
+    public void SetPresenter(TextPresenter? presenter)
     {
-        if (this._parent != null)
-            this._parent.PropertyChanged -= new EventHandler<AvaloniaPropertyChangedEventArgs>(this.OnParentPropertyChanged);
-        this._parent = parent;
-        if (this._parent != null)
-            this._parent.PropertyChanged += new EventHandler<AvaloniaPropertyChangedEventArgs>(this.OnParentPropertyChanged);
-        TextPresenter presenter1 = this._presenter;
-        if (presenter1 != null)
-        {
-            presenter1.CaretBoundsChanged -= (EventHandler) ((s, e) => this.RaiseCursorRectangleChanged());
-        }
-        this._presenter = presenter;
-        if (this._presenter != null)
-            this._presenter.CaretBoundsChanged += (EventHandler) ((s, e) => this.RaiseCursorRectangleChanged());
         this.RaiseTextViewVisualChanged();
         this.RaiseCursorRectangleChanged();
     }

--- a/src/Ursa/Controls/IPv4Box/IPv4BoxInputMethodClient.cs
+++ b/src/Ursa/Controls/IPv4Box/IPv4BoxInputMethodClient.cs
@@ -1,0 +1,44 @@
+using Avalonia;
+using Avalonia.Controls.Presenters;
+using Avalonia.Input.TextInput;
+
+namespace Ursa.Controls;
+
+public class IPv4BoxInputMethodClient:TextInputMethodClient
+{
+    private TextPresenter? _presenter;
+    public override Visual TextViewVisual => _presenter;
+    public override bool SupportsPreedit => false;
+    public override bool SupportsSurroundingText => true;
+
+    public override string SurroundingText
+    {
+        get;
+    }
+    public override Rect CursorRectangle { get; }
+    public override TextSelection Selection { get; set; }
+    private IPv4Box? _parent;
+    public void SetPresenter(TextPresenter? presenter, IPv4Box? parent)
+    {
+        if (this._parent != null)
+            this._parent.PropertyChanged -= new EventHandler<AvaloniaPropertyChangedEventArgs>(this.OnParentPropertyChanged);
+        this._parent = parent;
+        if (this._parent != null)
+            this._parent.PropertyChanged += new EventHandler<AvaloniaPropertyChangedEventArgs>(this.OnParentPropertyChanged);
+        TextPresenter presenter1 = this._presenter;
+        if (presenter1 != null)
+        {
+            presenter1.CaretBoundsChanged -= (EventHandler) ((s, e) => this.RaiseCursorRectangleChanged());
+        }
+        this._presenter = presenter;
+        if (this._presenter != null)
+            this._presenter.CaretBoundsChanged += (EventHandler) ((s, e) => this.RaiseCursorRectangleChanged());
+        this.RaiseTextViewVisualChanged();
+        this.RaiseCursorRectangleChanged();
+    }
+    
+    private void OnParentPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+    {
+        this.RaiseSelectionChanged();
+    }
+}


### PR DESCRIPTION
This PR partially fix IME issue of IPv4Box on Android. 

Notice: It only enables IME when IPv4Box got focus. If you close IME and click the control again, it still won't work. (Sorry don't know how to fix this issue. PR is welcomed. )