### PR TITLE
Add Splash Window

### DIFF
--- a/demo/Sandbox/App.axaml.cs
+++ b/demo/Sandbox/App.axaml.cs
@@ -1,4 +1,5 @@
 using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
@@ -21,10 +22,7 @@ public partial class App : Application
             // Line below is needed to remove Avalonia data validation.
             // Without this line you will get duplicate validations from both Avalonia and CT
             BindingPlugins.DataValidators.RemoveAt(0);
-            desktop.MainWindow = new MainWindow
-            {
-                DataContext = new MainWindowViewModel(),
-            };
+            desktop.MainWindow = new MainSplashWindow();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/demo/Sandbox/Views/MainSplashWindow.axaml
+++ b/demo/Sandbox/Views/MainSplashWindow.axaml
@@ -1,0 +1,12 @@
+<u:SplashWindow xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:u="https://irihi.tech/ursa"
+        mc:Ignorable="d" d:DesignWidth="800"
+        d:DesignHeight="450"
+        CountDown="0:0:2"
+        x:Class="Sandbox.Views.MainSplashWindow"
+        Title="MainSplashWindow">
+    Welcome to Avalonia Splash Window!
+</u:SplashWindow>

--- a/demo/Sandbox/Views/MainSplashWindow.axaml.cs
+++ b/demo/Sandbox/Views/MainSplashWindow.axaml.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+using System.Timers;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Avalonia.Threading;
+using Sandbox.ViewModels;
+using Ursa.Controls;
+
+namespace Sandbox.Views;
+
+public partial class MainSplashWindow : SplashWindow
+{
+    public MainSplashWindow()
+    {
+        InitializeComponent();
+    }
+    
+    protected override async Task<Window> CreateNextWindow()
+    {
+        return new MainWindow()
+        {
+            DataContext = new MainWindowViewModel()
+        };
+    }
+}

--- a/demo/Ursa.Demo/App.axaml.cs
+++ b/demo/Ursa.Demo/App.axaml.cs
@@ -18,10 +18,7 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            desktop.MainWindow = new MainWindow()
-            {
-                DataContext = new MainViewViewModel(),
-            };
+            desktop.MainWindow = new MainSplashWindow();
         }
         else if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)
         {

--- a/demo/Ursa.Demo/App.axaml.cs
+++ b/demo/Ursa.Demo/App.axaml.cs
@@ -18,7 +18,10 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            desktop.MainWindow = new MainSplashWindow();
+            desktop.MainWindow = new MvvmSplashWindow()
+            {
+                DataContext = new SplashViewModel()
+            };
         }
         else if (ApplicationLifetime is ISingleViewApplicationLifetime singleView)
         {

--- a/demo/Ursa.Demo/ViewModels/SplashViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/SplashViewModel.cs
@@ -1,0 +1,38 @@
+using System;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Irihi.Avalonia.Shared.Contracts;
+
+namespace Ursa.Demo.ViewModels;
+
+public partial class SplashViewModel: ObservableObject, IDialogContext
+{
+    [ObservableProperty] private double _progress;
+    private Random _r = new();
+
+    public SplashViewModel()
+    {
+        DispatcherTimer.Run(OnUpdate, TimeSpan.FromMilliseconds(200), DispatcherPriority.Default);
+    }
+
+    private bool OnUpdate()
+    {
+        Progress += 10 * _r.NextDouble();
+        if (Progress <= 100)
+        {
+            return true;
+        }
+        else
+        {
+            RequestClose?.Invoke(this, null);
+            return false;
+        }
+    }
+    
+    public void Close()
+    {
+        RequestClose?.Invoke(this, null);
+    }
+
+    public event EventHandler<object?>? RequestClose;
+}

--- a/demo/Ursa.Demo/ViewModels/SplashViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/SplashViewModel.cs
@@ -12,7 +12,7 @@ public partial class SplashViewModel: ObservableObject, IDialogContext
 
     public SplashViewModel()
     {
-        DispatcherTimer.Run(OnUpdate, TimeSpan.FromMilliseconds(200), DispatcherPriority.Default);
+        DispatcherTimer.Run(OnUpdate, TimeSpan.FromMilliseconds(20), DispatcherPriority.Default);
     }
 
     private bool OnUpdate()

--- a/demo/Ursa.Demo/ViewModels/SplashViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/SplashViewModel.cs
@@ -24,14 +24,14 @@ public partial class SplashViewModel: ObservableObject, IDialogContext
         }
         else
         {
-            RequestClose?.Invoke(this, null);
+            RequestClose?.Invoke(this, true);
             return false;
         }
     }
     
     public void Close()
     {
-        RequestClose?.Invoke(this, null);
+        RequestClose?.Invoke(this, false);
     }
 
     public event EventHandler<object?>? RequestClose;

--- a/demo/Ursa.Demo/Views/MainSplashWindow.axaml
+++ b/demo/Ursa.Demo/Views/MainSplashWindow.axaml
@@ -2,22 +2,11 @@
     x:Class="Ursa.Demo.Views.MainSplashWindow"
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:iri="https://irihi.tech/shared"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:u="https://irihi.tech/ursa"
     Title="MainSplashWindow"
     Width="400"
-    Height="400"
-    d:DesignHeight="450"
-    d:DesignWidth="800"
-    CountDown="0:0:3"
-    ExtendClientAreaChromeHints="NoChrome"
-    ExtendClientAreaTitleBarHeightHint="0"
-    ExtendClientAreaToDecorationsHint="True"
-    SystemDecorations="None"
-    WindowStartupLocation="CenterScreen"
-    mc:Ignorable="d">
+    Height="400">
     <Grid
         HorizontalAlignment="Center"
         VerticalAlignment="Center"

--- a/demo/Ursa.Demo/Views/MainSplashWindow.axaml
+++ b/demo/Ursa.Demo/Views/MainSplashWindow.axaml
@@ -17,7 +17,7 @@
             Grid.Column="0"
             Width="64"
             Margin="0,0,16,0"
-            Fill="{DynamicResource SemiGrey5}" />
+            Fill="{DynamicResource SemiColorText2}" />
         <StackPanel Grid.Row="0" Grid.Column="1">
             <TextBlock
                 Classes="H2"

--- a/demo/Ursa.Demo/Views/MainSplashWindow.axaml
+++ b/demo/Ursa.Demo/Views/MainSplashWindow.axaml
@@ -1,0 +1,54 @@
+<u:SplashWindow
+    x:Class="Ursa.Demo.Views.MainSplashWindow"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:iri="https://irihi.tech/shared"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:u="https://irihi.tech/ursa"
+    Title="MainSplashWindow"
+    Width="400"
+    Height="400"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    CountDown="0:0:3"
+    ExtendClientAreaChromeHints="NoChrome"
+    ExtendClientAreaTitleBarHeightHint="0"
+    ExtendClientAreaToDecorationsHint="True"
+    SystemDecorations="None"
+    WindowStartupLocation="CenterScreen"
+    mc:Ignorable="d">
+    <Grid
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        ColumnDefinitions="Auto, Auto"
+        RowDefinitions="Auto, Auto">
+        <iri:IrihiLogo
+            Grid.Row="0"
+            Grid.Column="0"
+            Width="64"
+            Margin="0,0,16,0"
+            Fill="{DynamicResource SemiGrey5}" />
+        <StackPanel Grid.Row="0" Grid.Column="1">
+            <TextBlock
+                Classes="H2"
+                Text="铱泓科技"
+                Theme="{DynamicResource TitleTextBlock}" />
+            <TextBlock FontWeight="Bold" Text="IRIHI Technology" />
+        </StackPanel>
+        <StackPanel
+            Grid.Row="1"
+            Grid.Column="0"
+            Grid.ColumnSpan="2">
+            <TextBlock
+                Margin="0,12,0,0"
+                HorizontalAlignment="Center"
+                FontSize="14"
+                Text="聚焦生产力的美学进化" />
+            <TextBlock
+                HorizontalAlignment="Center"
+                FontSize="14"
+                Text="Aesthetic Evolution of Productivity" />
+        </StackPanel>
+    </Grid>
+</u:SplashWindow>

--- a/demo/Ursa.Demo/Views/MainSplashWindow.axaml.cs
+++ b/demo/Ursa.Demo/Views/MainSplashWindow.axaml.cs
@@ -14,7 +14,7 @@ public partial class MainSplashWindow : SplashWindow
         InitializeComponent();
     }
 
-    protected override async Task<Window> CreateNextWindow()
+    protected override async Task<Window?> CreateNextWindow()
     {
         return new MainWindow()
         {

--- a/demo/Ursa.Demo/Views/MainSplashWindow.axaml.cs
+++ b/demo/Ursa.Demo/Views/MainSplashWindow.axaml.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Ursa.Controls;
+using Ursa.Demo.ViewModels;
+
+namespace Ursa.Demo.Views;
+
+public partial class MainSplashWindow : SplashWindow
+{
+    public MainSplashWindow()
+    {
+        InitializeComponent();
+    }
+
+    protected override async Task<Window> CreateNextWindow()
+    {
+        return new MainWindow()
+        {
+            DataContext = new MainViewViewModel()
+        };
+    }
+}

--- a/demo/Ursa.Demo/Views/MainWindow.axaml
+++ b/demo/Ursa.Demo/Views/MainWindow.axaml
@@ -13,6 +13,7 @@
     d:DesignWidth="800"
     x:CompileBindings="True"
     x:DataType="viewModels:MainWindowViewModel"
+    WindowStartupLocation="CenterScreen"
     Icon="/Assets/Ursa.ico"
     IsFullScreenButtonVisible="{OnPlatform True, macOS=False}"
     IsManagedResizerVisible="{OnPlatform False, Linux=True}"

--- a/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml
+++ b/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml
@@ -1,48 +1,54 @@
-<u:SplashWindow xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:u="https://irihi.tech/ursa"
-        xmlns:viewModels="clr-namespace:Ursa.Demo.ViewModels"
-        xmlns:iri="https://irihi.tech/shared"
-        mc:Ignorable="d" 
-        Width="400" Height="400"
-        CountDown="{x:Null}"
-        x:DataType="viewModels:SplashViewModel"
-        x:Class="Ursa.Demo.Views.MvvmSplashWindow"
-        Title="MvvmSplashWindow">
-        <Grid
+<u:SplashWindow
+    x:Class="Ursa.Demo.Views.MvvmSplashWindow"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:iri="https://irihi.tech/shared"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:u="https://irihi.tech/ursa"
+    xmlns:viewModels="clr-namespace:Ursa.Demo.ViewModels"
+    Title="MvvmSplashWindow"
+    Width="400"
+    Height="400"
+    x:DataType="viewModels:SplashViewModel"
+    CountDown="{x:Null}"
+    mc:Ignorable="d">
+    <Grid
+        HorizontalAlignment="Center"
+        VerticalAlignment="Center"
+        ColumnDefinitions="Auto, Auto"
+        RowDefinitions="Auto, Auto, Auto">
+        <iri:IrihiLogo
+            Grid.Row="0"
+            Grid.Column="0"
+            Width="64"
+            Margin="0,0,16,0"
+            Fill="{DynamicResource SemiGrey5}" />
+        <StackPanel Grid.Row="0" Grid.Column="1">
+            <TextBlock
+                Classes="H2"
+                Text="铱泓科技"
+                Theme="{DynamicResource TitleTextBlock}" />
+            <TextBlock FontWeight="Bold" Text="IRIHI Technology" />
+        </StackPanel>
+        <ProgressBar
+            Grid.Row="1"
+            Grid.ColumnSpan="2"
+            Margin="0,16,0,0"
+            Value="{Binding Progress}" />
+        <StackPanel
+            Grid.Row="2"
+            Grid.Column="0"
+            Grid.ColumnSpan="2">
+            <TextBlock
+                Margin="0,12,0,0"
                 HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                ColumnDefinitions="Auto, Auto"
-                RowDefinitions="Auto, Auto, Auto">
-                <iri:IrihiLogo
-                        Grid.Row="0"
-                        Grid.Column="0"
-                        Width="64"
-                        Margin="0,0,16,0"
-                        Fill="{DynamicResource SemiGrey5}" />
-                <StackPanel Grid.Row="0" Grid.Column="1">
-                        <TextBlock
-                                Classes="H2"
-                                Text="铱泓科技"
-                                Theme="{DynamicResource TitleTextBlock}" />
-                        <TextBlock FontWeight="Bold" Text="IRIHI Technology" />
-                </StackPanel>
-                <ProgressBar Grid.Row="1" Grid.ColumnSpan="2" Value="{Binding Progress}" Margin="0 16 0 0"/>
-                <StackPanel
-                        Grid.Row="2"
-                        Grid.Column="0"
-                        Grid.ColumnSpan="2">
-                        <TextBlock
-                                Margin="0,12,0,0"
-                                HorizontalAlignment="Center"
-                                FontSize="14"
-                                Text="聚焦生产力的美学进化" />
-                        <TextBlock
-                                HorizontalAlignment="Center"
-                                FontSize="14"
-                                Text="Aesthetic Evolution of Productivity" />
-                </StackPanel>
-        </Grid>
+                FontSize="14"
+                Text="聚焦生产力的美学进化" />
+            <TextBlock
+                HorizontalAlignment="Center"
+                FontSize="14"
+                Text="Aesthetic Evolution of Productivity" />
+        </StackPanel>
+    </Grid>
 </u:SplashWindow>

--- a/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml
+++ b/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml
@@ -1,0 +1,48 @@
+<u:SplashWindow xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:u="https://irihi.tech/ursa"
+        xmlns:viewModels="clr-namespace:Ursa.Demo.ViewModels"
+        xmlns:iri="https://irihi.tech/shared"
+        mc:Ignorable="d" 
+        Width="400" Height="400"
+        CountDown="{x:Null}"
+        x:DataType="viewModels:SplashViewModel"
+        x:Class="Ursa.Demo.Views.MvvmSplashWindow"
+        Title="MvvmSplashWindow">
+        <Grid
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                ColumnDefinitions="Auto, Auto"
+                RowDefinitions="Auto, Auto, Auto">
+                <iri:IrihiLogo
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Width="64"
+                        Margin="0,0,16,0"
+                        Fill="{DynamicResource SemiGrey5}" />
+                <StackPanel Grid.Row="0" Grid.Column="1">
+                        <TextBlock
+                                Classes="H2"
+                                Text="铱泓科技"
+                                Theme="{DynamicResource TitleTextBlock}" />
+                        <TextBlock FontWeight="Bold" Text="IRIHI Technology" />
+                </StackPanel>
+                <ProgressBar Grid.Row="1" Grid.ColumnSpan="2" Value="{Binding Progress}" Margin="0 16 0 0"/>
+                <StackPanel
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2">
+                        <TextBlock
+                                Margin="0,12,0,0"
+                                HorizontalAlignment="Center"
+                                FontSize="14"
+                                Text="聚焦生产力的美学进化" />
+                        <TextBlock
+                                HorizontalAlignment="Center"
+                                FontSize="14"
+                                Text="Aesthetic Evolution of Productivity" />
+                </StackPanel>
+        </Grid>
+</u:SplashWindow>

--- a/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml
+++ b/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml
@@ -23,7 +23,7 @@
             Grid.Column="0"
             Width="64"
             Margin="0,0,16,0"
-            Fill="{DynamicResource SemiGrey5}" />
+            Fill="{DynamicResource SemiColorText2}" />
         <StackPanel Grid.Row="0" Grid.Column="1">
             <TextBlock
                 Classes="H2"
@@ -33,6 +33,7 @@
         </StackPanel>
         <ProgressBar
             Grid.Row="1"
+            Grid.Column="0"
             Grid.ColumnSpan="2"
             Margin="0,16,0,0"
             Value="{Binding Progress}" />

--- a/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml.cs
+++ b/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Ursa.Controls;
+using Ursa.Demo.ViewModels;
+
+namespace Ursa.Demo.Views;
+
+public partial class MvvmSplashWindow : SplashWindow
+{
+    public MvvmSplashWindow()
+    {
+        InitializeComponent();
+    }
+
+    protected override async Task<Window> CreateNextWindow()
+    {
+        return new MainWindow()
+        {
+            DataContext = new MainViewViewModel()
+        };
+    }
+}

--- a/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml.cs
+++ b/demo/Ursa.Demo/Views/MvvmSplashWindow.axaml.cs
@@ -14,11 +14,15 @@ public partial class MvvmSplashWindow : SplashWindow
         InitializeComponent();
     }
 
-    protected override async Task<Window> CreateNextWindow()
+    protected override async Task<Window?> CreateNextWindow()
     {
-        return new MainWindow()
+        if (this.DialogResult is true)
         {
-            DataContext = new MainViewViewModel()
-        };
+            return new MainWindow()
+            {
+                DataContext = new MainViewViewModel()
+            };
+        }
+        return null;
     }
 }

--- a/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
@@ -1,0 +1,27 @@
+﻿<ResourceDictionary
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:u="https://irihi.tech/ursa">
+    <ControlTheme x:Key="{x:Type u:SplashWindow}" TargetType="u:SplashWindow">
+        <Setter Property="CountDown" Value="0:0:3" />
+        <Setter Property="Background" Value="{DynamicResource WindowDefaultBackground}" />
+        <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource WindowDefaultBackground}" />
+        <Setter Property="Foreground" Value="{DynamicResource WindowDefaultForeground}" />
+        <Setter Property="FontSize" Value="{DynamicResource DefaultFontSize}" />
+        <Setter Property="FontFamily" Value="{DynamicResource DefaultFontFamily}" />
+        <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
+        <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="0" />
+        <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
+        <Setter Property="WindowStartupLocation" Value="CenterScreen" />
+        <Setter Property="SystemDecorations">
+            <OnPlatform>
+                <On Options="Default, Windows, macOS">
+                    <SystemDecorations>Full</SystemDecorations>
+                </On>
+                <On Options="Linux">
+                    <SystemDecorations>None</SystemDecorations>
+                </On>
+            </OnPlatform>
+        </Setter>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
@@ -3,7 +3,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:u="https://irihi.tech/ursa">
     <ControlTheme x:Key="{x:Type u:SplashWindow}" TargetType="u:SplashWindow">
-        <Setter Property="CountDown" Value="0:0:3" />
         <Setter Property="Background" Value="{DynamicResource WindowDefaultBackground}" />
         <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource WindowDefaultBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource WindowDefaultForeground}" />

--- a/src/Ursa.Themes.Semi/Controls/_index.axaml
+++ b/src/Ursa.Themes.Semi/Controls/_index.axaml
@@ -56,5 +56,6 @@
         <ResourceInclude Source="UrsaWindow.axaml"/>
         <ResourceInclude Source="PinCode.axaml" />
         <ResourceInclude Source="PathPicker.axaml"/>
+        <ResourceInclude Source="SplashWindow.axaml"/>
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/Ursa/Windows/SplashWindow.cs
+++ b/src/Ursa/Windows/SplashWindow.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
+using Irihi.Avalonia.Shared.Contracts;
 
 namespace Ursa.Controls;
 
@@ -17,6 +18,24 @@ public abstract class SplashWindow: Window
     {
         get => GetValue(CountDownProperty);
         set => SetValue(CountDownProperty, value);
+    }
+    
+    static SplashWindow()
+    {
+        DataContextProperty.Changed.AddClassHandler<SplashWindow, object?>((window, e) =>
+            window.OnDataContextChange(e));
+    }
+    
+    private void OnDataContextChange(AvaloniaPropertyChangedEventArgs<object?> args)
+    {
+        if (args.OldValue.Value is IDialogContext oldContext) oldContext.RequestClose -= OnContextRequestClose;
+
+        if (args.NewValue.Value is IDialogContext newContext) newContext.RequestClose += OnContextRequestClose;
+    }
+    
+    private void OnContextRequestClose(object? sender, object? args)
+    {
+        Close(args);
     }
 
     protected override void OnLoaded(RoutedEventArgs e)
@@ -49,6 +68,11 @@ public abstract class SplashWindow: Window
                 }
                 nextWindow.Show();
                 Close();
+                if (DataContext is IDialogContext idc)
+                {
+                    idc.Close();
+                    idc.RequestClose -= OnContextRequestClose;
+                }
                 return;
             }
         }

--- a/src/Ursa/Windows/SplashWindow.cs
+++ b/src/Ursa/Windows/SplashWindow.cs
@@ -8,6 +8,8 @@ namespace Ursa.Controls;
 
 public abstract class SplashWindow: Window
 {
+    protected override Type StyleKeyOverride => typeof(SplashWindow);
+
     public static readonly StyledProperty<TimeSpan?> CountDownProperty = AvaloniaProperty.Register<SplashWindow, TimeSpan?>(
         nameof(CountDown));
 

--- a/src/Ursa/Windows/SplashWindow.cs
+++ b/src/Ursa/Windows/SplashWindow.cs
@@ -1,0 +1,56 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Interactivity;
+using Avalonia.Threading;
+
+namespace Ursa.Controls;
+
+public abstract class SplashWindow: Window
+{
+    public static readonly StyledProperty<TimeSpan?> CountDownProperty = AvaloniaProperty.Register<SplashWindow, TimeSpan?>(
+        nameof(CountDown));
+
+    public TimeSpan? CountDown
+    {
+        get => GetValue(CountDownProperty);
+        set => SetValue(CountDownProperty, value);
+    }
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        if (CountDown != null && CountDown != TimeSpan.Zero)
+        {
+            DispatcherTimer.RunOnce(Close, CountDown.Value);
+        }
+    }
+
+    protected virtual Task<bool> CanClose() => Task.FromResult(true);
+    protected abstract Task<Window> CreateNextWindow();
+    
+    private bool _canClose;
+    
+    protected override sealed async void OnClosing(WindowClosingEventArgs e)
+    {
+        VerifyAccess();
+        if (!_canClose)
+        {
+            e.Cancel = true;
+            _canClose = await CanClose();
+            if (_canClose)
+            {
+                var nextWindow = await CreateNextWindow();
+                if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime lifetime)
+                {
+                    lifetime.MainWindow = nextWindow;
+                }
+                nextWindow.Show();
+                Close();
+                return;
+            }
+        }
+        base.OnClosing(e);
+        
+    }
+}


### PR DESCRIPTION
This new control is just to simplify the setup of SplashScreen which is commonly used in desktop application. The implementation is simple, just replace the application MainWindow if applicable. 

There is a simple CountDown implementation that handles most commonly used scenario. 

Limitations:
1. Only desktop environment.
2. Prism shell is not supported as it's impossible to change `PrismApplicationBase.MainWindow`. 
