### PR TITLE
Fix CalendarView style and DateTimePicker frozen issue

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/Calendar.axaml
+++ b/src/Ursa.Themes.Semi/Controls/Calendar.axaml
@@ -199,31 +199,19 @@
                         Grid.Row="0"
                         Margin="0,0,0,16"
                         ColumnDefinitions="Auto, Auto,*, Auto, Auto">
-                        <Button
+                        <u:IconButton
                             Name="{x:Static u:CalendarView.PART_FastPreviousButton}"
+                            Classes="Tertiary"
                             Grid.Column="0"
-                            HorizontalContentAlignment="Left"
-                            Foreground="{TemplateBinding Foreground}"
-                            Theme="{DynamicResource BorderlessButton}">
-                            <PathIcon
-                                Theme="{StaticResource InnerPathIcon}"
-                                Classes="Large"
-                                Data="{DynamicResource CalendarViewFastForwardGlyph}"
-                                Foreground="{DynamicResource CalendarItemIconForeground}" />
-                        </Button>
+                            Icon="{DynamicResource CalendarViewFastForwardGlyph}"
+                            Theme="{DynamicResource BorderlessIconButton}"/>
 
-                        <Button
+                        <u:IconButton
                             Name="{x:Static u:CalendarView.PART_PreviousButton}"
                             Grid.Column="1"
-                            HorizontalContentAlignment="Left"
-                            Foreground="{TemplateBinding Foreground}"
-                            Theme="{DynamicResource BorderlessButton}">
-                            <PathIcon
-                                Theme="{StaticResource InnerPathIcon}"
-                                Classes="Large"
-                                Data="{DynamicResource CalendarItemPreviousIconGlyph}"
-                                Foreground="{DynamicResource CalendarItemIconForeground}" />
-                        </Button>
+                            Classes="Tertiary"
+                            Icon="{DynamicResource CalendarItemPreviousIconGlyph}"
+                            Theme="{DynamicResource BorderlessIconButton}"/>
 
                         <Grid Grid.Column="2" ColumnDefinitions="*, *">
                             <Button
@@ -246,30 +234,18 @@
                                 HorizontalContentAlignment="Center"
                                 IsVisible="True" />
                         </Grid>
-                        <Button
+                        <u:IconButton
                             Name="{x:Static u:CalendarView.PART_NextButton}"
                             Grid.Column="3"
-                            HorizontalContentAlignment="Left"
-                            Foreground="{TemplateBinding Foreground}"
-                            Theme="{DynamicResource BorderlessButton}">
-                            <PathIcon
-                                Theme="{StaticResource InnerPathIcon}"
-                                Classes="Large"
-                                Data="{DynamicResource CalendarItemNextIconGlyph}"
-                                Foreground="{DynamicResource CalendarItemIconForeground}" />
-                        </Button>
-                        <Button
+                            Classes="Tertiary"
+                            Icon="{DynamicResource CalendarItemNextIconGlyph}"
+                            Theme="{DynamicResource BorderlessIconButton}"/>
+                        <u:IconButton
                             Name="{x:Static u:CalendarView.PART_FastNextButton}"
                             Grid.Column="4"
-                            HorizontalContentAlignment="Left"
-                            Foreground="{TemplateBinding Foreground}"
-                            Theme="{DynamicResource BorderlessButton}">
-                            <PathIcon
-                                Theme="{StaticResource InnerPathIcon}"
-                                Classes="Large"
-                                Data="{DynamicResource CalendarViewFastBackwardGlyph}"
-                                Foreground="{DynamicResource CalendarItemIconForeground}" />
-                        </Button>
+                            Classes="Tertiary"
+                            Icon="{DynamicResource CalendarViewFastBackwardGlyph}"
+                            Theme="{DynamicResource BorderlessIconButton}"/>
                     </Grid>
                     <Grid
                         Name="{x:Static u:CalendarView.PART_MonthGrid}"

--- a/src/Ursa/Controls/DateTimePicker/DatePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePicker.cs
@@ -203,10 +203,8 @@ public class DatePicker: DatePickerBase, IClearControl
         FocusChanged(IsKeyboardFocusWithin);
         var top = TopLevel.GetTopLevel(this);
         var element = top?.FocusManager?.GetFocusedElement();
-        if (element is Visual v && _popup?.IsInsidePopup(v)==true)
-        {
-            return;
-        }
+        if (element is Visual v && _popup?.IsInsidePopup(v) == true)return;
+        if (Equals(element, _textBox))return;
         CommitInput(true);
         SetCurrentValue(IsDropdownOpenProperty, false);
     }

--- a/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
@@ -487,7 +487,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
             return;
         }
 
-        if (element == _startTextBox || element == _endTextBox)
+        if (Equals(element, _startTextBox) || Equals(element, _endTextBox))
         {
             return;
         }

--- a/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
@@ -234,7 +234,7 @@ public class DateTimePicker : DatePickerBase
             return;
         }
 
-        if (element == _textBox)
+        if (Equals(element, _textBox))
         {
             return;
         }

--- a/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
@@ -233,6 +233,11 @@ public class DateTimePicker : DatePickerBase
         {
             return;
         }
+
+        if (element == _textBox)
+        {
+            return;
+        }
         CommitInput(true);
         SetCurrentValue(IsDropdownOpenProperty, false);
     }

--- a/src/Ursa/Controls/DateTimePicker/TimePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/TimePicker.cs
@@ -222,7 +222,7 @@ public class TimePicker : TimePickerBase, IClearControl
         var top = TopLevel.GetTopLevel(this);
         var element = top?.FocusManager?.GetFocusedElement();
         if (element is Visual v && _popup?.IsInsidePopup(v) == true) return;
-        if (element == _textBox) return;
+        if (Equals(element, _textBox)) return;
         CommitInput(true);
         SetCurrentValue(IsDropdownOpenProperty, false);
     }

--- a/src/Ursa/Controls/DateTimePicker/TimeRangePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/TimeRangePicker.cs
@@ -277,7 +277,7 @@ public class TimeRangePicker : TimePickerBase, IClearControl
         var top = TopLevel.GetTopLevel(this);
         var element = top?.FocusManager?.GetFocusedElement();
         if (element is Visual v && _popup?.IsInsidePopup(v) == true) return;
-        if (element == _startTextBox || element == _endTextBox) return;
+        if (Equals(element, _startTextBox) || Equals(element, _endTextBox)) return;
         CommitInput(true);
         SetCurrentValue(IsDropdownOpenProperty, false);
     }

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePicker/CalendarViewHelper.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePicker/CalendarViewHelper.cs
@@ -11,44 +11,44 @@ internal static class CalendarViewHelper
     {
         var previousButton = calendarView.GetTemplateChildren()
                                          .FirstOrDefault(a => a.Name == CalendarView.PART_PreviousButton);
-        Assert.IsType<Button>(previousButton);
-        var button = (Button)previousButton;
-        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Assert.IsAssignableFrom<Button>(previousButton);
+        var button = previousButton as Button;
+        button?.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
     }
     
     internal static void ClickNext(this CalendarView calendarView)
     {
         var nextButton = calendarView.GetTemplateChildren()
                                      .FirstOrDefault(a => a.Name == CalendarView.PART_NextButton);
-        Assert.IsType<Button>(nextButton);
-        var button = (Button)nextButton;
-        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Assert.IsAssignableFrom<Button>(nextButton);
+        var button = nextButton as Button;
+        button?.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
     }
     
     internal static void ClickFastNext(this CalendarView calendarView)
     {
         var nextButton = calendarView.GetTemplateChildren()
                                      .FirstOrDefault(a => a.Name == CalendarView.PART_FastNextButton);
-        Assert.IsType<Button>(nextButton);
-        var button = (Button)nextButton;
-        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Assert.IsAssignableFrom<Button>(nextButton);
+        var button = nextButton as Button;
+        button?.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
     }
     
     internal static void ClickFastPrevious(this CalendarView calendarView)
     {
         var previousButton = calendarView.GetTemplateChildren()
                                          .FirstOrDefault(a => a.Name == CalendarView.PART_FastPreviousButton);
-        Assert.IsType<Button>(previousButton);
-        var button = (Button)previousButton;
-        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Assert.IsAssignableFrom<Button>(previousButton);
+        var button = previousButton as Button;
+        button?.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
     }
     
     internal static void ClickHeaderButton(this CalendarView calendarView)
     {
         var headerButton = calendarView.GetTemplateChildren()
                                        .FirstOrDefault(a => a.Name == CalendarView.PART_HeaderButton);
-        Assert.IsType<Button>(headerButton);
-        var button = (Button)headerButton;
-        button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+        Assert.IsAssignableFrom<Button>(headerButton);
+        var button = headerButton as Button;
+        button?.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
     }
 }


### PR DESCRIPTION
1. Use IconButton for CalendarView navigation button to reduce their sizes. Thus the overall width can be stable.
2. Fix an issue when DateTimePicker lost focus and triggered a popup racing condition. 