### PR TITLE
Add a`DialogTriggerIntegration`,which functions similarly to`PathPicker`.

### DIFF
--- a/src/Ursa/Controls/DialogTriggerIntegration/DialogTriggerIntegration.cs
+++ b/src/Ursa/Controls/DialogTriggerIntegration/DialogTriggerIntegration.cs
@@ -1,0 +1,7 @@
+﻿using Avalonia.Controls;
+
+namespace Ursa.Controls;
+
+public class DialogTriggerIntegration : ContentControl
+{
+}


### PR DESCRIPTION
This will make the integration of pop-up windows with the MVVM design pattern simpler in Ursa.Users will no longer need to manipulate the UI directly in the ViewModel to obtain the required parameters,or reinvent the wheel to implement the same functionality as this control.