### PR TITLE
Allow setting titlebar HitTest from UrsaWindow

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
@@ -66,6 +66,7 @@
                         <VisualLayerManager.ChromeOverlayLayer>
                             <Panel Margin="{Binding $parent[u:UrsaWindow].OffScreenMargin}">
                                 <u:TitleBar
+                                    IsTitleBarHitTestVisible="{Binding $parent[u:UrsaWindow].(u:TitleBar.IsTitleBarHitTestVisible)}"
                                     Margin="{Binding $parent[u:UrsaWindow].TitleBarMargin}"
                                     Content="{Binding $parent[u:UrsaWindow].TitleBarContent}"
                                     IsTitleVisible="{Binding $parent[u:UrsaWindow].IsTitleBarVisible}"
@@ -109,7 +110,7 @@
                         <Border
                             Name="PART_Background"
                             Background="{TemplateBinding Background}"
-                            IsHitTestVisible="True" />
+                            IsHitTestVisible="{TemplateBinding IsTitleBarHitTestVisible}" />
                         <Grid HorizontalAlignment="Stretch" ColumnDefinitions="Auto, *, Auto, Auto">
                             <ContentPresenter
                                 Grid.Column="0"

--- a/src/Ursa/Controls/TitleBar/TitleBar.cs
+++ b/src/Ursa/Controls/TitleBar/TitleBar.cs
@@ -42,6 +42,17 @@ public class TitleBar: ContentControl
         get => GetValue(IsTitleVisibleProperty);
         set => SetValue(IsTitleVisibleProperty, value);
     }
+
+    public static readonly AttachedProperty<bool> IsTitleBarHitTestVisibleProperty =
+        AvaloniaProperty.RegisterAttached<TitleBar, Window, bool>("IsTitleBarHitTestVisible", defaultValue: true);
+    public static void SetIsTitleBarHitTestVisible(Window obj, bool value) => obj.SetValue(IsTitleBarHitTestVisibleProperty, value);
+    public static bool GetIsTitleBarHitTestVisible(Window obj) => obj.GetValue(IsTitleBarHitTestVisibleProperty);
+    
+    public bool IsTitleBarHitTestVisible
+    {
+        get => GetValue(IsTitleBarHitTestVisibleProperty);
+        set => SetValue(IsTitleBarHitTestVisibleProperty, value);
+    }
     
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {


### PR DESCRIPTION
Introduce a new AttachedProperty: u:TitleBar.IsTitleBarHitTestVisible

Setting this property to false (on u:UrsaWindow) will disable u:TitleBar default "Drag and DoubleTap" behavior.

