### PR TITLE
SplashWindow default theme update. 

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
@@ -3,11 +3,6 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:u="https://irihi.tech/ursa">
     <ControlTheme x:Key="{x:Type u:SplashWindow}" TargetType="u:SplashWindow" BasedOn="{StaticResource {x:Type Window}}">
-        <Setter Property="Background" Value="{DynamicResource WindowDefaultBackground}" />
-        <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource WindowDefaultBackground}" />
-        <Setter Property="Foreground" Value="{DynamicResource WindowDefaultForeground}" />
-        <Setter Property="FontSize" Value="{DynamicResource DefaultFontSize}" />
-        <Setter Property="FontFamily" Value="{DynamicResource DefaultFontFamily}" />
         <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
         <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="0" />
         <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />

--- a/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
@@ -2,7 +2,7 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:u="https://irihi.tech/ursa">
-    <ControlTheme x:Key="{x:Type u:SplashWindow}" TargetType="u:SplashWindow">
+    <ControlTheme x:Key="{x:Type u:SplashWindow}" TargetType="u:SplashWindow" BasedOn="{StaticResource {x:Type Window}}">
         <Setter Property="Background" Value="{DynamicResource WindowDefaultBackground}" />
         <Setter Property="TransparencyBackgroundFallback" Value="{DynamicResource WindowDefaultBackground}" />
         <Setter Property="Foreground" Value="{DynamicResource WindowDefaultForeground}" />

--- a/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/SplashWindow.axaml
@@ -2,7 +2,10 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:u="https://irihi.tech/ursa">
-    <ControlTheme x:Key="{x:Type u:SplashWindow}" TargetType="u:SplashWindow" BasedOn="{StaticResource {x:Type Window}}">
+    <ControlTheme
+        x:Key="{x:Type u:SplashWindow}"
+        BasedOn="{StaticResource {x:Type Window}}"
+        TargetType="u:SplashWindow">
         <Setter Property="ExtendClientAreaChromeHints" Value="NoChrome" />
         <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="0" />
         <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />


### PR DESCRIPTION
This pull request includes a modification to the `SplashWindow.axaml` file to improve the theme management for the `SplashWindow` control. The change involves using a base theme for the control to inherit default properties, which simplifies the theme definition and ensures consistency.

Theme management improvement:

* [`src/Ursa.Themes.Semi/Controls/SplashWindow.axaml`](diffhunk://#diff-455db7918e2d35200c8af6d9b2e57b5e36cb039c2f8391a453b4798722a433e0L5-R5): Modified the `ControlTheme` for `u:SplashWindow` to be based on the `Window` static resource, removing redundant property setters.