### PR TITLE
Add TryGetXXManager to WindowXXManager

### DIFF
--- a/demo/Ursa.Demo/Dialogs/CustomDemoDialog.axaml.cs
+++ b/demo/Ursa.Demo/Dialogs/CustomDemoDialog.axaml.cs
@@ -1,8 +1,11 @@
+using System;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Notifications;
 using Avalonia.Controls.Primitives;
 using Avalonia.VisualTree;
 using Ursa.Controls;
+using WindowNotificationManager = Ursa.Controls.WindowNotificationManager;
 
 namespace Ursa.Demo.Dialogs;
 
@@ -24,6 +27,13 @@ public partial class CustomDemoDialog : UserControl
         {
             _viewModel.NotificationManager = new WindowNotificationManager(visualLayerManager) { MaxItems = 3 };
             _viewModel.ToastManager = new WindowToastManager(visualLayerManager) { MaxItems = 3 };
+        }
+
+        WindowNotificationManager.TryGetNotificationManager(visualLayerManager, out var manager);
+        if (manager is not null && _viewModel is not null)
+        {
+            Console.WriteLine(ReferenceEquals(_viewModel.NotificationManager, manager));
+            manager.Position = NotificationPosition.TopCenter;
         }
     }
 

--- a/demo/Ursa.Demo/Dialogs/CustomDemoDialog.axaml.cs
+++ b/demo/Ursa.Demo/Dialogs/CustomDemoDialog.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
@@ -23,24 +24,14 @@ public partial class CustomDemoDialog : UserControl
         base.OnAttachedToVisualTree(e);
         _viewModel = this.DataContext as CustomDemoDialogViewModel;
         var visualLayerManager = this.FindAncestorOfType<VisualLayerManager>();
-        if (visualLayerManager is not null && _viewModel is not null)
-        {
-            _viewModel.NotificationManager = new WindowNotificationManager(visualLayerManager) { MaxItems = 3 };
-            _viewModel.ToastManager = new WindowToastManager(visualLayerManager) { MaxItems = 3 };
-        }
-
-        WindowNotificationManager.TryGetNotificationManager(visualLayerManager, out var manager);
-        if (manager is not null && _viewModel is not null)
-        {
-            Console.WriteLine(ReferenceEquals(_viewModel.NotificationManager, manager));
-            manager.Position = NotificationPosition.TopCenter;
-        }
-    }
-
-    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-    {
-        base.OnDetachedFromVisualTree(e);
-        _viewModel?.NotificationManager?.Uninstall();
-        _viewModel?.ToastManager?.Uninstall();
+        if (_viewModel == null) return;
+        _viewModel.NotificationManager =
+            WindowNotificationManager.TryGetNotificationManager(visualLayerManager, out var notificationManager)
+                ? notificationManager
+                : new WindowNotificationManager(visualLayerManager) { MaxItems = 3 };
+        _viewModel.ToastManager = WindowToastManager.TryGetToastManager(visualLayerManager, out var toastManager)
+            ? toastManager
+            : new WindowToastManager(visualLayerManager) { MaxItems = 3 };
+        Debug.Assert(WindowNotificationManager.TryGetNotificationManager(visualLayerManager, out _));
     }
 }

--- a/demo/Ursa.Demo/Pages/NotificationDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/NotificationDemo.axaml.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.LogicalTree;
 using Ursa.Controls;
 using Ursa.Demo.ViewModels;
 
@@ -21,12 +20,11 @@ public partial class NotificationDemo : UserControl
     {
         base.OnAttachedToVisualTree(e);
         var topLevel = TopLevel.GetTopLevel(this);
-        _viewModel.NotificationManager = new WindowNotificationManager(topLevel) { MaxItems = 3 };
-    }
 
-    protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
-    {
-        base.OnDetachedFromLogicalTree(e);
-        _viewModel.NotificationManager?.Uninstall();
+        WindowNotificationManager.TryGetNotificationManager(topLevel, out var manager);
+        if (manager is not null)
+        {
+            _viewModel.NotificationManager = manager;
+        }
     }
 }

--- a/demo/Ursa.Demo/ViewModels/MainViewViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/MainViewViewModel.cs
@@ -1,16 +1,19 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using Avalonia;
+using Avalonia.Controls.Notifications;
 using Avalonia.Styling;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Messaging;
-using Ursa.Controls;
 using Ursa.Themes.Semi;
+using Notification = Ursa.Controls.Notification;
+using WindowNotificationManager = Ursa.Controls.WindowNotificationManager;
 
 namespace Ursa.Demo.ViewModels;
 
 public partial class MainViewViewModel : ViewModelBase
 {
+    public WindowNotificationManager? NotificationManager { get; set; }
     public MenuViewModel Menus { get; set; } = new MenuViewModel();
 
     private object? _content;
@@ -107,6 +110,10 @@ public partial class MainViewViewModel : ViewModelBase
         if (app is not null)
         {
             app.RequestedThemeVariant = newValue.Theme;
+            NotificationManager?.Show(
+                new Notification("Theme changed", $"Theme changed to {newValue.Name}"),
+                type: NotificationType.Success,
+                classes: ["Light"]);
         }
     }
 

--- a/demo/Ursa.Demo/Views/MainView.axaml.cs
+++ b/demo/Ursa.Demo/Views/MainView.axaml.cs
@@ -1,11 +1,28 @@
+using Avalonia;
 using Avalonia.Controls;
+using Ursa.Controls;
+using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Views;
 
 public partial class MainView : UserControl
 {
+    private MainViewViewModel? _viewModel;
+
     public MainView()
     {
         InitializeComponent();
+    }
+
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnAttachedToVisualTree(e);
+        _viewModel = DataContext as MainViewViewModel;
+        var topLevel = TopLevel.GetTopLevel(this);
+        WindowNotificationManager.TryGetNotificationManager(topLevel, out var manager);
+        if (manager is not null && _viewModel is not null)
+        {
+            _viewModel.NotificationManager = manager;
+        }
     }
 }

--- a/demo/Ursa.Demo/Views/MainWindow.axaml.cs
+++ b/demo/Ursa.Demo/Views/MainWindow.axaml.cs
@@ -5,9 +5,12 @@ namespace Ursa.Demo.Views;
 
 public partial class MainWindow : UrsaWindow
 {
+    public WindowNotificationManager? NotificationManager { get; set; }
+
     public MainWindow()
     {
         InitializeComponent();
+        NotificationManager = new WindowNotificationManager(this) { MaxItems = 3 };
     }
 
     protected override async Task<bool> CanClose()

--- a/src/Ursa/Controls/Notification/WindowNotificationManager.cs
+++ b/src/Ursa/Controls/Notification/WindowNotificationManager.cs
@@ -70,6 +70,12 @@ public class WindowNotificationManager : WindowMessageManager, INotificationMana
         VerticalAlignmentProperty.OverrideDefaultValue<WindowNotificationManager>(VerticalAlignment.Stretch);
     }
 
+    /// <summary>
+    /// Tries to get the <see cref="WindowNotificationManager"/> from a <see cref="Visual"/>.
+    /// </summary>
+    /// <param name="visual">A <see cref="Visual"/> that is either a <see cref="Window"/> or a <see cref="VisualLayerManager"/>.</param>
+    /// <param name="manager">The existing <see cref="WindowNotificationManager"/> if found, or null if not found.</param>
+    /// <returns>True if a <see cref="WindowNotificationManager"/> is found; otherwise, false.</returns>
     public static bool TryGetNotificationManager(Visual? visual, out WindowNotificationManager? manager)
     {
         manager = visual?.FindDescendantOfType<WindowNotificationManager>();

--- a/src/Ursa/Controls/Notification/WindowNotificationManager.cs
+++ b/src/Ursa/Controls/Notification/WindowNotificationManager.cs
@@ -5,6 +5,7 @@ using Avalonia.Controls.Notifications;
 using Avalonia.Controls.Primitives;
 using Avalonia.Layout;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 
 namespace Ursa.Controls;
 
@@ -67,6 +68,12 @@ public class WindowNotificationManager : WindowMessageManager, INotificationMana
     {
         HorizontalAlignmentProperty.OverrideDefaultValue<WindowNotificationManager>(HorizontalAlignment.Stretch);
         VerticalAlignmentProperty.OverrideDefaultValue<WindowNotificationManager>(VerticalAlignment.Stretch);
+    }
+
+    public static bool TryGetNotificationManager(Visual? visual, out WindowNotificationManager? manager)
+    {
+        manager = visual?.FindDescendantOfType<WindowNotificationManager>();
+        return manager is not null;
     }
 
     /// <inheritdoc/>

--- a/src/Ursa/Controls/NotificationShared/WindowMessageManager.cs
+++ b/src/Ursa/Controls/NotificationShared/WindowMessageManager.cs
@@ -84,12 +84,6 @@ public abstract class WindowMessageManager : TemplatedControl
         }
     }
 
-    public static bool TryGetMessageManager(Visual? visual, out WindowMessageManager? manager)
-    {
-        manager = visual?.FindDescendantOfType<WindowMessageManager>();
-        return manager is not null;
-    }
-
     protected void TopLevelOnTemplateApplied(object? sender, TemplateAppliedEventArgs e)
     {
         if (Parent is AdornerLayer adornerLayer)

--- a/src/Ursa/Controls/NotificationShared/WindowMessageManager.cs
+++ b/src/Ursa/Controls/NotificationShared/WindowMessageManager.cs
@@ -84,6 +84,12 @@ public abstract class WindowMessageManager : TemplatedControl
         }
     }
 
+    public static bool TryGetMessageManager(Visual? visual, out WindowMessageManager? manager)
+    {
+        manager = visual?.FindDescendantOfType<WindowMessageManager>();
+        return manager is not null;
+    }
+
     protected void TopLevelOnTemplateApplied(object? sender, TemplateAppliedEventArgs e)
     {
         if (Parent is AdornerLayer adornerLayer)

--- a/src/Ursa/Controls/Toast/WindowToastManager.cs
+++ b/src/Ursa/Controls/Toast/WindowToastManager.cs
@@ -35,6 +35,12 @@ public class WindowToastManager : WindowMessageManager, IToastManager
     {
     }
 
+    /// <summary>
+    /// Tries to get the <see cref="WindowToastManager"/> from a <see cref="Window"/> or <see cref="VisualLayerManager"/>.
+    /// </summary>
+    /// <param name="visual">A <see cref="Visual"/> that is either a <see cref="Window"/> or a <see cref="VisualLayerManager"/>.</param>
+    /// <param name="manager">The existing <see cref="WindowToastManager"/> if found, or null if not found.</param>
+    /// <returns>True if a <see cref="WindowToastManager"/> is found; otherwise, false.</returns>
     public static bool TryGetToastManager(Visual? visual, out WindowToastManager? manager)
     {
         manager = visual?.FindDescendantOfType<WindowToastManager>();

--- a/src/Ursa/Controls/Toast/WindowToastManager.cs
+++ b/src/Ursa/Controls/Toast/WindowToastManager.cs
@@ -1,7 +1,9 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
 using Avalonia.Controls.Notifications;
 using Avalonia.Controls.Primitives;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 
 namespace Ursa.Controls;
 
@@ -31,6 +33,12 @@ public class WindowToastManager : WindowMessageManager, IToastManager
 
     public WindowToastManager(VisualLayerManager? visualLayerManager) : base(visualLayerManager)
     {
+    }
+
+    public static bool TryGetToastManager(Visual? visual, out WindowToastManager? manager)
+    {
+        manager = visual?.FindDescendantOfType<WindowToastManager>();
+        return manager is not null;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
This pull request includes several changes to improve the handling and management of notifications and toasts in the Ursa application. The changes primarily focus on introducing new methods to retrieve existing notification and toast managers and updating the related code to utilize these methods.

Improvements to notification and toast management:

* [`src/Ursa/Controls/Notification/WindowNotificationManager.cs`](diffhunk://#diff-9a5f3f3eb8c4c01b55dab9b9edcc5e1918ce43bd90bd1f2f8ffee3fdf565d6a8R73-R84): Added the `TryGetNotificationManager` method to retrieve an existing `WindowNotificationManager` from a `Visual` element.
* [`src/Ursa/Controls/Toast/WindowToastManager.cs`](diffhunk://#diff-6a2d72b0a8a41926ded0c64cf816f0baefec10aa557a153cd7f82d822e0ef280R38-R49): Added the `TryGetToastManager` method to retrieve an existing `WindowToastManager` from a `Visual` element.

Update demo accordingly. 