### PR TITLE
Demo: ensure notification manager is created. 

### DIFF
--- a/demo/Ursa.Demo/Pages/NotificationDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/NotificationDemo.axaml.cs
@@ -20,11 +20,10 @@ public partial class NotificationDemo : UserControl
     {
         base.OnAttachedToVisualTree(e);
         var topLevel = TopLevel.GetTopLevel(this);
-
-        WindowNotificationManager.TryGetNotificationManager(topLevel, out var manager);
-        if (manager is not null)
-        {
-            _viewModel.NotificationManager = manager;
-        }
+        if (topLevel is null)
+            return;
+        _viewModel.NotificationManager = WindowNotificationManager.TryGetNotificationManager(topLevel, out var manager)
+            ? manager
+            : new WindowNotificationManager(topLevel);
     }
 }

--- a/demo/Ursa.Demo/Views/MainView.axaml.cs
+++ b/demo/Ursa.Demo/Views/MainView.axaml.cs
@@ -19,10 +19,10 @@ public partial class MainView : UserControl
         base.OnAttachedToVisualTree(e);
         _viewModel = DataContext as MainViewViewModel;
         var topLevel = TopLevel.GetTopLevel(this);
-        WindowNotificationManager.TryGetNotificationManager(topLevel, out var manager);
-        if (manager is not null && _viewModel is not null)
-        {
-            _viewModel.NotificationManager = manager;
-        }
+        if (topLevel is null || _viewModel is null)
+            return;
+        _viewModel.NotificationManager = WindowNotificationManager.TryGetNotificationManager(topLevel, out var manager)
+            ? manager
+            : new WindowNotificationManager(topLevel);
     }
 }


### PR DESCRIPTION
This pull request includes changes to improve the initialization of the `NotificationManager` in the `OnAttachedToVisualTree` method for both `NotificationDemo` and `MainView` components. The changes ensure that a new `WindowNotificationManager` is created if the existing one cannot be retrieved, and they handle cases where `topLevel` or `_viewModel` might be null.

Improvements to `NotificationManager` initialization:

* [`demo/Ursa.Demo/Pages/NotificationDemo.axaml.cs`](diffhunk://#diff-ea1134050b280d31ef0ccdd5994035b2a2654d0542bbf2752d8d64cb9dbedba9L23-R27): Modified the `OnAttachedToVisualTree` method to create a new `WindowNotificationManager` if the existing one cannot be retrieved, and added a null check for `topLevel`.
* [`demo/Ursa.Demo/Views/MainView.axaml.cs`](diffhunk://#diff-afddc99bb4a8d05059ad20d6892ea1efa8c48aa932ba50c5ec429bcf04628c12L22-R26): Updated the `OnAttachedToVisualTree` method to handle null cases for both `topLevel` and `_viewModel`, and to create a new `WindowNotificationManager` if necessary.