### PR TITLE
remove scale transform in Button &  simplify OnPlatform use case

### DIFF
--- a/demo/Ursa.Demo/Views/MainWindow.axaml
+++ b/demo/Ursa.Demo/Views/MainWindow.axaml
@@ -15,8 +15,8 @@
     x:DataType="viewModels:MainWindowViewModel"
     WindowStartupLocation="CenterScreen"
     Icon="/Assets/Ursa.ico"
-    IsFullScreenButtonVisible="{OnPlatform True, macOS=False}"
-    IsManagedResizerVisible="{OnPlatform False, Linux=True}"
+    IsFullScreenButtonVisible="{OnPlatform {x:True}, macOS={x:False}}"
+    IsManagedResizerVisible="{OnPlatform {x:False}, Linux={x:True}}"
     mc:Ignorable="d">
     <u:UrsaWindow.RightContent>
         <views:TitleBarRightContent />

--- a/src/Ursa.Themes.Semi/Controls/IconButton.axaml
+++ b/src/Ursa.Themes.Semi/Controls/IconButton.axaml
@@ -86,10 +86,6 @@
             </ControlTemplate>
         </Setter>
 
-        <Style Selector="^:pressed">
-            <Setter Property="RenderTransform" Value="scale(0.98)" />
-        </Style>
-
         <Style Selector="^.Primary">
             <Setter Property="Foreground" Value="{DynamicResource ButtonDefaultPrimaryForeground}" />
         </Style>

--- a/src/Ursa.Themes.Semi/Controls/ScrollToButton.axaml
+++ b/src/Ursa.Themes.Semi/Controls/ScrollToButton.axaml
@@ -23,9 +23,6 @@
                 </Border>
             </ControlTemplate>
         </Setter>
-        <Style Selector="^:pressed">
-            <Setter Property="RenderTransform" Value="scale(0.98)" />
-        </Style>
         <Style Selector="^:pointerover /template/ Border#PART_Background">
             <Setter Property="BorderBrush" Value="{DynamicResource ButtonDefaultPointeroverBorderBrush}" />
             <Setter Property="Background" Value="{DynamicResource ButtonDefaultPointeroverBackground}" />
@@ -66,9 +63,6 @@
                 </Border>
             </ControlTemplate>
         </Setter>
-        <Style Selector="^:pressed">
-            <Setter Property="RenderTransform" Value="scale(0.98)" />
-        </Style>
         <Style Selector="^:pointerover /template/ Border#PART_Background">
             <Setter Property="Background" Value="{DynamicResource ButtonSolidPrimaryPointeroverBackground}" />
             <Setter Property="BorderBrush" Value="{DynamicResource ButtonSolidPrimaryPointeroverBorderBrush}" />

--- a/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
+++ b/src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml
@@ -11,39 +11,12 @@
         <Setter Property="ExtendClientAreaTitleBarHeightHint" Value="-1" />
         <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
         <Setter Property="u:OverlayDialogHost.IsModalStatusScope" Value="True" />
-        <Setter Property="IsMinimizeButtonVisible">
-            <OnPlatform>
-                <On Options="Default, Windows, Linux">
-                    <x:Boolean>True</x:Boolean>
-                </On>
-                <On Options="macOS">
-                    <x:Boolean>False</x:Boolean>
-                </On>
-            </OnPlatform>
-        </Setter>
-        <Setter Property="IsRestoreButtonVisible">
-            <OnPlatform>
-                <On Options="Default, Windows, Linux">
-                    <x:Boolean>True</x:Boolean>
-                </On>
-                <On Options="macOS">
-                    <x:Boolean>False</x:Boolean>
-                </On>
-            </OnPlatform>
-        </Setter>
-        <Setter Property="IsCloseButtonVisible">
-            <OnPlatform>
-                <On Options="Default, Windows, Linux">
-                    <x:Boolean>True</x:Boolean>
-                </On>
-                <On Options="macOS">
-                    <x:Boolean>False</x:Boolean>
-                </On>
-            </OnPlatform>
-        </Setter>
+        <Setter Property="IsMinimizeButtonVisible" Value="{OnPlatform {x:True},macOS={x:False}}" />
+        <Setter Property="IsRestoreButtonVisible" Value="{OnPlatform {x:True},macOS={x:False}}" />
+        <Setter Property="IsCloseButtonVisible" Value="{OnPlatform {x:True},macOS={x:False}}"/>
         <Setter Property="SystemDecorations">
             <OnPlatform>
-                <On Options="Default, Windows, macOS">
+                <On Options="Default">
                     <SystemDecorations>Full</SystemDecorations>
                 </On>
                 <On Options="Linux">


### PR DESCRIPTION
This pull request makes several changes to improve platform-specific property handling and simplifies styles in the `Ursa` project. The key updates include refactoring platform-specific property definitions for clarity and removing redundant styles for pressed states in buttons.

### Platform-specific property handling improvements:
* Refactored `IsFullScreenButtonVisible` and `IsManagedResizerVisible` properties in `MainWindow.axaml` to use a more concise `OnPlatform` syntax with explicit `x:` namespace usage. (`demo/Ursa.Demo/Views/MainWindow.axaml`, [demo/Ursa.Demo/Views/MainWindow.axamlL18-R19](diffhunk://#diff-3a80804ae09127b0b5dffd5c27bb1aa3153275f8ae66b7c2a4a00a22b755e9daL18-R19))
* Simplified platform-specific definitions for `IsMinimizeButtonVisible`, `IsRestoreButtonVisible`, and `IsCloseButtonVisible` in `UrsaWindow.axaml` by replacing nested `OnPlatform` elements with single-line `Value` syntax. (`src/Ursa.Themes.Semi/Controls/UrsaWindow.axaml`, [src/Ursa.Themes.Semi/Controls/UrsaWindow.axamlL14-R19](diffhunk://#diff-376c2033beb2655980bc77fdd7d6a271d31c43426413d9e0a691b806a16dc640L14-R19))

### Style simplifications:
* Removed the redundant `^:pressed` style that applied a `scale(0.98)` transform in `IconButton.axaml`. (`src/Ursa.Themes.Semi/Controls/IconButton.axaml`, [src/Ursa.Themes.Semi/Controls/IconButton.axamlL89-L92](diffhunk://#diff-20920e613941153308e138c6bedae80b347cba81499b4bb391fe979872ea4302L89-L92))
* Removed the same `^:pressed` style from `ScrollToButton.axaml` in two separate locations. (`src/Ursa.Themes.Semi/Controls/ScrollToButton.axaml`, [[1]](diffhunk://#diff-7631d301d09bb655baa591c0c1ef55643d0ad5871173d392d08d92db9e944999L26-L28) [[2]](diffhunk://#diff-7631d301d09bb655baa591c0c1ef55643d0ad5871173d392d08d92db9e944999L69-L71)