### PR TITLE
Fix Badge position miscalculation

### DIFF
--- a/src/Ursa/Controls/Badge/Badge.cs
+++ b/src/Ursa/Controls/Badge/Badge.cs
@@ -65,8 +65,6 @@ public class Badge : HeaderedContentControl
 
     static Badge()
     {
-        HeaderProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
-        HeaderTemplateProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
         CornerPositionProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
         DotProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
         AffectsArrange<Badge>(HeaderProperty, HeaderTemplateProperty);

--- a/src/Ursa/Controls/Badge/Badge.cs
+++ b/src/Ursa/Controls/Badge/Badge.cs
@@ -2,7 +2,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
-using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Styling;
 using Ursa.Common;
@@ -67,7 +66,6 @@ public class Badge : HeaderedContentControl
     {
         CornerPositionProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
         DotProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
-        AffectsArrange<Badge>(HeaderProperty, HeaderTemplateProperty);
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
@@ -76,18 +74,20 @@ public class Badge : HeaderedContentControl
         _badgeContainer = e.NameScope.Find<Border>(PART_BadgeContainer);
     }
 
-    protected override void OnLoaded(RoutedEventArgs e)
+    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
     {
-        base.OnLoaded(e);
-        UpdateBadgePosition();
+        base.OnAttachedToVisualTree(e);
+        ApplyTemplate();
+        _badgeContainer?.AddHandler(SizeChangedEvent, OnBadgeSizeChanged);
     }
 
-    protected override Size ArrangeOverride(Size finalSize)
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
     {
-        var size = base.ArrangeOverride(finalSize);
-        UpdateBadgePosition();
-        return size;
+        _badgeContainer?.RemoveHandler(SizeChangedEvent, OnBadgeSizeChanged);
+        base.OnDetachedFromVisualTree(e);
     }
+
+    private void OnBadgeSizeChanged(object? sender, SizeChangedEventArgs e) => UpdateBadgePosition();
 
     private void UpdateBadgePosition()
     {

--- a/src/Ursa/Controls/Badge/Badge.cs
+++ b/src/Ursa/Controls/Badge/Badge.cs
@@ -72,22 +72,8 @@ public class Badge : HeaderedContentControl
     {
         base.OnApplyTemplate(e);
         _badgeContainer = e.NameScope.Find<Border>(PART_BadgeContainer);
+        _badgeContainer?.AddHandler(SizeChangedEvent, (_, _) => UpdateBadgePosition());
     }
-
-    protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
-    {
-        base.OnAttachedToVisualTree(e);
-        ApplyTemplate();
-        _badgeContainer?.AddHandler(SizeChangedEvent, OnBadgeSizeChanged);
-    }
-
-    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
-    {
-        _badgeContainer?.RemoveHandler(SizeChangedEvent, OnBadgeSizeChanged);
-        base.OnDetachedFromVisualTree(e);
-    }
-
-    private void OnBadgeSizeChanged(object? sender, SizeChangedEventArgs e) => UpdateBadgePosition();
 
     private void UpdateBadgePosition()
     {

--- a/src/Ursa/Controls/Badge/Badge.cs
+++ b/src/Ursa/Controls/Badge/Badge.cs
@@ -66,8 +66,10 @@ public class Badge : HeaderedContentControl
     static Badge()
     {
         HeaderProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
+        HeaderTemplateProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
         CornerPositionProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
         DotProperty.Changed.AddClassHandler<Badge>((badge, _) => badge.UpdateBadgePosition());
+        AffectsArrange<Badge>(HeaderProperty, HeaderTemplateProperty);
     }
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)

--- a/src/Ursa/Controls/Badge/Badge.cs
+++ b/src/Ursa/Controls/Badge/Badge.cs
@@ -70,10 +70,13 @@ public class Badge : HeaderedContentControl
 
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
+        _badgeContainer?.RemoveHandler(SizeChangedEvent, OnBadgeSizeChanged);
         base.OnApplyTemplate(e);
         _badgeContainer = e.NameScope.Find<Border>(PART_BadgeContainer);
-        _badgeContainer?.AddHandler(SizeChangedEvent, (_, _) => UpdateBadgePosition());
+        _badgeContainer?.AddHandler(SizeChangedEvent, OnBadgeSizeChanged);
     }
+
+    private void OnBadgeSizeChanged(object? sender, SizeChangedEventArgs e) => UpdateBadgePosition();
 
     private void UpdateBadgePosition()
     {


### PR DESCRIPTION
In the `Badge`, when the `Header` or `HeaderTemplate` changes, the `Bounds` value of `PART_BadgeContainer` is not updated before `UpdateBadgePosition` is called. Therefore, the Avalonia framework must be notified that changes to `HeaderProperty` and `HeaderTemplateProperty` should invalidate the arrange pass. This ensures that after `Bounds` is updated, `ArrangeOverride` is called again to recalculate the badge position.

---

* Change `Header`

  https://github.com/user-attachments/assets/0390cbf3-ead6-44bc-8445-1b3636a7fca5

* Change `HeaderTemplate`

  https://github.com/user-attachments/assets/97e23c96-daaf-4ef3-a349-b28b982cdf75

---

Fixes #661