### PR TITLE
feat: handle null image source in ImageViewer

### DIFF
--- a/src/Ursa/Controls/ImageViewer/ImageViewer.cs
+++ b/src/Ursa/Controls/ImageViewer/ImageViewer.cs
@@ -148,7 +148,20 @@ public class ImageViewer: TemplatedControl
     private void OnSourceChanged(AvaloniaPropertyChangedEventArgs args)
     {
         if(!IsLoaded) return;
-        IImage image = args.GetNewValue<IImage>();
+        IImage? image = args.GetNewValue<IImage?>();
+        if (image is null)
+        {
+            // Clear the image when Source is set to null
+            if (_image is not null)
+            {
+                _image.Width = double.NaN;
+                _image.Height = double.NaN;
+            }
+            Scale = 1;
+            _sourceMinScale = MinScale;
+            return;
+        }
+        
         Size size = image.Size;
         double width = this.Bounds.Width;
         double height = this.Bounds.Height;
@@ -163,7 +176,7 @@ public class ImageViewer: TemplatedControl
 
     private void OnStretchChanged(AvaloniaPropertyChangedEventArgs args)
     {
-        if (_image is null) return;
+        if (_image is null || Source is null || double.IsNaN(_image.Width) || double.IsNaN(_image.Height)) return;
         var stretch = args.GetNewValue<Stretch>();
         Scale = GetScaleRatio(Width / _image.Width, Height / _image.Height, stretch);
         _sourceMinScale = _image is not null ? Math.Min(Width * MinScale / _image.Width, Height * MinScale / _image.Height) : MinScale;


### PR DESCRIPTION
This pull request updates the `ImageViewer` control in `src/Ursa/Controls/ImageViewer/ImageViewer.cs` to improve handling of null values for the `Source` property and ensure proper behavior when the image dimensions are invalid. The changes enhance robustness and prevent potential errors during runtime.

### Null handling improvements:

* [`OnSourceChanged`](diffhunk://#diff-230258b47182e8de75fd114688eee36e63eb22a0875cf9556e339f8326b3b2e8L151-R164): Updated the method to handle cases where the `Source` property is set to null. It now clears the `_image` dimensions, resets the `Scale`, and sets `_sourceMinScale` to `MinScale` when the image is null.

### Validation for image dimensions:

* [`OnStretchChanged`](diffhunk://#diff-230258b47182e8de75fd114688eee36e63eb22a0875cf9556e339f8326b3b2e8L166-R179): Modified the method to include additional checks for invalid `_image` dimensions (`Width` or `Height` being `NaN`) and null `Source`. This ensures the scaling calculations are only performed with valid data.