### PR TITLE
Remove Unused ViewModel References from Demo Pages

### DIFF
--- a/demo/Ursa.Demo/Pages/BannerDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/BannerDemo.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,6 +7,5 @@ public partial class BannerDemo : UserControl
     public BannerDemo()
     {
         InitializeComponent();
-        this.DataContext = new BannerDemoViewModel();
     }
 }

--- a/demo/Ursa.Demo/Pages/ButtonGroupDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/ButtonGroupDemo.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,6 +7,5 @@ public partial class ButtonGroupDemo : UserControl
     public ButtonGroupDemo()
     {
         InitializeComponent();
-        DataContext = new ButtonGroupDemoViewModel();
     }
 }

--- a/demo/Ursa.Demo/Pages/DividerDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/DividerDemo.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,10 +7,5 @@ public partial class DividerDemo : UserControl
     public DividerDemo()
     {
         InitializeComponent();
-    }
-
-    private void InitializeComponent()
-    {
-        AvaloniaXamlLoader.Load(this);
     }
 }

--- a/demo/Ursa.Demo/Pages/ElasticWrapPanelDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/ElasticWrapPanelDemo.axaml.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,6 +7,5 @@ public partial class ElasticWrapPanelDemo : UserControl
     public ElasticWrapPanelDemo()
     {
         InitializeComponent();
-        DataContext = new ElasticWrapPanelDemoViewModel();
     }
 }

--- a/demo/Ursa.Demo/Pages/LoadingDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/LoadingDemo.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Avalonia.Markup.Xaml;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,10 +7,5 @@ public partial class LoadingDemo : UserControl
     public LoadingDemo()
     {
         InitializeComponent();
-    }
-
-    private void InitializeComponent()
-    {
-        AvaloniaXamlLoader.Load(this);
     }
 }

--- a/demo/Ursa.Demo/Pages/MessageBoxDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/MessageBoxDemo.axaml.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,6 +7,5 @@ public partial class MessageBoxDemo : UserControl
     public MessageBoxDemo()
     {
         InitializeComponent();
-        this.DataContext = new MessageBoxDemoViewModel();
     }
 }

--- a/demo/Ursa.Demo/Pages/NavMenuDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/NavMenuDemo.axaml.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,6 +7,5 @@ public partial class NavMenuDemo : UserControl
     public NavMenuDemo()
     {
         InitializeComponent();
-        DataContext = new NavMenuDemoViewModel();
     }
 }

--- a/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/NumericUpDownDemo.axaml.cs
@@ -1,7 +1,6 @@
-﻿using Avalonia.Controls;
-using System.Diagnostics;
+﻿using System.Diagnostics;
+using Avalonia.Controls;
 using Ursa.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -10,7 +9,6 @@ public partial class NumericUpDownDemo : UserControl
     public NumericUpDownDemo()
     {
         InitializeComponent();
-        DataContext = new NumericUpDownDemoViewModel();
         numd.ValueChanged += Numd_ValueChanged;
     }
 

--- a/demo/Ursa.Demo/Pages/PaginationDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/PaginationDemo.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,6 +7,5 @@ public partial class PaginationDemo : UserControl
     public PaginationDemo()
     {
         InitializeComponent();
-        this.DataContext = new PaginationDemoViewModel();
     }
 }

--- a/demo/Ursa.Demo/Pages/RangeSliderDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/RangeSliderDemo.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,6 +7,5 @@ public partial class RangeSliderDemo : UserControl
     public RangeSliderDemo()
     {
         InitializeComponent();
-        this.DataContext = new RangeSliderDemoViewModel();
     }
 }

--- a/demo/Ursa.Demo/Pages/RatingDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/RatingDemo.axaml.cs
@@ -1,5 +1,4 @@
 ﻿using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,6 +7,5 @@ public partial class RatingDemo : UserControl
     public RatingDemo()
     {
         InitializeComponent();
-        this.DataContext = new RatingDemoViewModel();
     }
 }

--- a/demo/Ursa.Demo/Pages/SkeletonDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/SkeletonDemo.axaml.cs
@@ -1,14 +1,11 @@
 using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
-namespace Ursa.Demo.Pages
+namespace Ursa.Demo.Pages;
+
+public partial class SkeletonDemo : UserControl
 {
-    public partial class SkeletonDemo : UserControl
+    public SkeletonDemo()
     {
-        public SkeletonDemo()
-        {
-            InitializeComponent();
-            DataContext = new SkeletonDemoViewModel();
-        }
+        InitializeComponent();
     }
 }

--- a/demo/Ursa.Demo/Pages/TimelineDemo.axaml.cs
+++ b/demo/Ursa.Demo/Pages/TimelineDemo.axaml.cs
@@ -1,5 +1,4 @@
 using Avalonia.Controls;
-using Ursa.Demo.ViewModels;
 
 namespace Ursa.Demo.Pages;
 
@@ -8,6 +7,5 @@ public partial class TimelineDemo : UserControl
     public TimelineDemo()
     {
         InitializeComponent();
-        this.DataContext = new TimelineDemoViewModel();
     }
 }


### PR DESCRIPTION
This pull request makes several changes to the `Ursa.Demo` project, primarily focusing on simplifying the codebase by removing unnecessary `DataContext` assignments and unused `using` directives. Additionally, it removes redundant `InitializeComponent` methods in some files.

### Removal of `DataContext` Assignments:
* Removed explicit `DataContext` assignments from constructors in multiple demo pages, such as `BannerDemo`, `ButtonGroupDemo`, `ElasticWrapPanelDemo`, `MessageBoxDemo`, `PaginationDemo`, `RangeSliderDemo`, `RatingDemo`, `SkeletonDemo`, and `TimelineDemo`. This simplifies the code by relying on default mechanisms for setting the `DataContext`. [[1]](diffhunk://#diff-7b5a6797cf7ffce04e7bcde579413a1162e53168d880f294878e56525fafcbd4L11) [[2]](diffhunk://#diff-51101296469463dd8c0dfc7bcb78d6e24ad937f569b0a15b70d62bebe8ffe14eL11) [[3]](diffhunk://#diff-217bdc81b3f6371b9841e0493aa3f98adace8f15337e39dcc771c185ec288922L11) [[4]](diffhunk://#diff-2d282930ba5744fbd0afd54254a7d9710c6f06516125d5f570d83de55afba3baL11) [[5]](diffhunk://#diff-b4144aee661d958d60c16b6447bae6f4cf5d0fae3125bc78d3ef6398062873faL11) [[6]](diffhunk://#diff-9f19384b932412abc4d9ee3680d1be1c38ce88d165bb86e0c2a6f65154bd7041L11) [[7]](diffhunk://#diff-d8e10745bfb83675003da7f3240ff6b2c1718ea1d3ec12e9771309759ec8695eL11) [[8]](diffhunk://#diff-f5061f2dcb3ab96b50f50024b6b39e0ad2a30286d76c93359a5bab4de7f86e90L2-L12) [[9]](diffhunk://#diff-fa2b3cccfeebe19aacc7babf2b5b1aac7d9b99a389b47b45a3867439c8fa489eL11)

### Removal of Unused `using` Directives:
* Removed unused `using` directives, such as `Ursa.Demo.ViewModels` and `Avalonia.Markup.Xaml`, from various demo page files to clean up the code. [[1]](diffhunk://#diff-7b5a6797cf7ffce04e7bcde579413a1162e53168d880f294878e56525fafcbd4L2) [[2]](diffhunk://#diff-51101296469463dd8c0dfc7bcb78d6e24ad937f569b0a15b70d62bebe8ffe14eL2) [[3]](diffhunk://#diff-c210512fb5d37011021788420ee9900c91c1aecf0729d04ff76dcc8359638515L2) [[4]](diffhunk://#diff-217bdc81b3f6371b9841e0493aa3f98adace8f15337e39dcc771c185ec288922L2) [[5]](diffhunk://#diff-5cbb1fc0579913930cb3d12700e42521c952e8d2f4f544db195432cd42d68c2aL2) [[6]](diffhunk://#diff-2d282930ba5744fbd0afd54254a7d9710c6f06516125d5f570d83de55afba3baL2) [[7]](diffhunk://#diff-73c851eb97a8ee19b1ac684978dd721af86aa8db3d5cb695c5c39110fa7ec2b9L2) [[8]](diffhunk://#diff-2a9c84393d5bbb0a677cad4b9263b49179995fbc585b7e0e6bf774823ab436ddL1-L4) [[9]](diffhunk://#diff-b4144aee661d958d60c16b6447bae6f4cf5d0fae3125bc78d3ef6398062873faL2) [[10]](diffhunk://#diff-9f19384b932412abc4d9ee3680d1be1c38ce88d165bb86e0c2a6f65154bd7041L2) [[11]](diffhunk://#diff-d8e10745bfb83675003da7f3240ff6b2c1718ea1d3ec12e9771309759ec8695eL2) [[12]](diffhunk://#diff-f5061f2dcb3ab96b50f50024b6b39e0ad2a30286d76c93359a5bab4de7f86e90L2-L12) [[13]](diffhunk://#diff-fa2b3cccfeebe19aacc7babf2b5b1aac7d9b99a389b47b45a3867439c8fa489eL2)

### Removal of Redundant `InitializeComponent` Methods:
* Removed custom `InitializeComponent` method definitions in `DividerDemo` and `LoadingDemo`, as they are no longer necessary. [[1]](diffhunk://#diff-c210512fb5d37011021788420ee9900c91c1aecf0729d04ff76dcc8359638515L12-L16) [[2]](diffhunk://#diff-5cbb1fc0579913930cb3d12700e42521c952e8d2f4f544db195432cd42d68c2aL12-L16)