### PR TITLE
Keyboard Navigation for NavMenu

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/NavMenu.axaml
+++ b/src/Ursa.Themes.Semi/Controls/NavMenu.axaml
@@ -10,30 +10,31 @@
         <Setter Property="SubMenuIndent" Value="24" />
         <Setter Property="Template">
             <ControlTemplate TargetType="u:NavMenu">
-                <DockPanel LastChildFill="True">
-                    <ContentPresenter Content="{TemplateBinding Header}" DockPanel.Dock="Top" />
-                    <ContentPresenter Content="{TemplateBinding Footer}" DockPanel.Dock="Bottom" />
-                    <ScrollViewer
-                        HorizontalAlignment="Stretch"
-                        HorizontalScrollBarVisibility="Disabled"
-                        AllowAutoHide="True"
-                        VerticalScrollBarVisibility="Auto">
-                        <ScrollViewer.Styles>
-                            <Style Selector="ScrollViewer /template/ ScrollBar">
-                                <Setter Property="Opacity" Value="0" />
-                            </Style>
-                            <Style Selector="ScrollViewer:pointerover">
-                                <Style Selector="^ /template/ ScrollBar#PART_HorizontalScrollBar">
-                                    <Setter Property="Opacity" Value="1" />
-                                </Style>
-                                <Style Selector="^ /template/ ScrollBar#PART_VerticalScrollBar">
-                                    <Setter Property="Opacity" Value="1" />
-                                </Style>
-                            </Style>
-                        </ScrollViewer.Styles>
-                        <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}" />
-                    </ScrollViewer>
-                </DockPanel>
+                <Grid RowDefinitions="Auto, *, Auto">
+                    <ContentPresenter Content="{TemplateBinding Header}" />
+					<ScrollViewer
+						Grid.Row="1"
+						HorizontalAlignment="Stretch"
+						HorizontalScrollBarVisibility="Disabled"
+						AllowAutoHide="True"
+						VerticalScrollBarVisibility="Auto">
+						<ScrollViewer.Styles>
+							<Style Selector="ScrollViewer /template/ ScrollBar">
+								<Setter Property="Opacity" Value="0" />
+							</Style>
+							<Style Selector="ScrollViewer:pointerover">
+								<Style Selector="^ /template/ ScrollBar#PART_HorizontalScrollBar">
+									<Setter Property="Opacity" Value="1" />
+								</Style>
+								<Style Selector="^ /template/ ScrollBar#PART_VerticalScrollBar">
+									<Setter Property="Opacity" Value="1" />
+								</Style>
+							</Style>
+						</ScrollViewer.Styles>
+						<ItemsPresenter Name="PART_ItemsPresenter" ItemsPanel="{TemplateBinding ItemsPanel}" />
+					</ScrollViewer>
+                    <ContentPresenter Grid.Row="2" Content="{TemplateBinding Footer}" />
+                </Grid>
             </ControlTemplate>
         </Setter>
         <Style Selector="^:not(:horizontal-collapsed)">
@@ -182,6 +183,12 @@
         <Style Selector="^ /template/ ContentPresenter#PART_HeaderPresenter:pointerover">
             <Setter Property="Foreground" Value="{DynamicResource ListBoxItemPointeroverForeground}" />
         </Style>
+		<Style Selector="^:focus /template/ Border#PART_Border">
+			<Setter Property="Background" Value="{DynamicResource ListBoxItemPointeroverBackground}" />
+		</Style>
+		<Style Selector="^:focus /template/ ContentPresenter#PART_HeaderPresenter">
+			<Setter Property="Foreground" Value="{DynamicResource ListBoxItemPointeroverForeground}" />
+		</Style>
         <Style Selector="^:horizontal-collapsed:first-level">
             <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Style Selector="^ /template/ Border#PART_Border">


### PR DESCRIPTION
Added keyboard navigation to `NavMenu`:

- Arrow keys to move between items  
- Enter to activate  
- Left/Right to expand or collapse submenus

Also includes code cleanup:

- Refactored `NavMenu` for clarity and method order
- Simplified `NavMenuItem` and removed pointer duplication

https://github.com/user-attachments/assets/c59e27e1-814f-4cde-add6-267432bdc8d5