### PR TITLE
replace PathIcon with Button in ClosableTag

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/TagInput.axaml
+++ b/src/Ursa.Themes.Semi/Controls/TagInput.axaml
@@ -124,16 +124,17 @@
                     BorderThickness="{TemplateBinding BorderThickness}"
                     CornerRadius="3">
                     <DockPanel LastChildFill="True">
-                        <PathIcon
+                        <Button
                             Name="{x:Static u:ClosableTag.PART_CloseButton}"
-                            Theme="{StaticResource InnerPathIcon}"
-                            Classes="Small"
-                            Margin="4,0,0,0"
-                            Background="Transparent"
-                            Data="{DynamicResource ClosableTagCloseIconGlyph}"
+                            Theme="{DynamicResource InnerIconButton}"
                             DockPanel.Dock="Right"
+                            Width="12"
+                            Height="12"
+                            Margin="4,0,0,0"
                             Foreground="{DynamicResource SemiColorText2}"
-                            Cursor="Hand" />
+                            Command="{TemplateBinding Command}"
+                            CommandParameter="{TemplateBinding}"
+                            Content="{StaticResource ClosableTagCloseIconGlyph}" />
                         <ContentPresenter
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding Content}"
@@ -145,10 +146,10 @@
                 </Border>
             </ControlTemplate>
         </Setter>
-        <Style Selector="^ /template/ PathIcon#PART_CloseButton:pointerover">
+        <Style Selector="^ /template/ Button#PART_CloseButton:pointerover">
             <Setter Property="Foreground" Value="{DynamicResource SemiColorText1}" />
         </Style>
-        <Style Selector="^ /template/ PathIcon#PART_CloseButton:pressed">
+        <Style Selector="^ /template/ Button#PART_CloseButton:pressed">
             <Setter Property="Foreground" Value="{DynamicResource SemiColorText0}" />
         </Style>
     </ControlTheme>

--- a/src/Ursa.Themes.Semi/Controls/TagInput.axaml
+++ b/src/Ursa.Themes.Semi/Controls/TagInput.axaml
@@ -2,6 +2,9 @@
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:u="https://irihi.tech/ursa">
+    <Design.PreviewWith>
+        <u:ClosableTag Content="Closable Tag"/>
+    </Design.PreviewWith>
     <ControlTheme x:Key="{x:Type u:TagInput}" TargetType="u:TagInput">
         <Setter Property="InputTheme" Value="{DynamicResource TagInputTextBoxTheme}" />
         <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -115,7 +118,7 @@
             <ControlTemplate TargetType="u:ClosableTag">
                 <Border
                     Margin="1"
-                    Padding="4,2"
+                    Padding="8,4,4,4"
                     Background="{TemplateBinding Background}"
                     BorderBrush="{TemplateBinding BorderBrush}"
                     BorderThickness="{TemplateBinding BorderThickness}"
@@ -125,11 +128,12 @@
                             Name="{x:Static u:ClosableTag.PART_CloseButton}"
                             Theme="{StaticResource InnerPathIcon}"
                             Classes="Small"
-                            Margin="4,0"
+                            Margin="4,0,0,0"
                             Background="Transparent"
                             Data="{DynamicResource ClosableTagCloseIconGlyph}"
                             DockPanel.Dock="Right"
-                            Foreground="{TemplateBinding Foreground}" />
+                            Foreground="{DynamicResource SemiColorText2}"
+                            Cursor="Hand" />
                         <ContentPresenter
                             VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                             Content="{TemplateBinding Content}"
@@ -141,5 +145,11 @@
                 </Border>
             </ControlTemplate>
         </Setter>
+        <Style Selector="^ /template/ PathIcon#PART_CloseButton:pointerover">
+            <Setter Property="Foreground" Value="{DynamicResource SemiColorText1}" />
+        </Style>
+        <Style Selector="^ /template/ PathIcon#PART_CloseButton:pressed">
+            <Setter Property="Foreground" Value="{DynamicResource SemiColorText0}" />
+        </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/src/Ursa/Controls/TagInput/ClosableTag.cs
+++ b/src/Ursa/Controls/TagInput/ClosableTag.cs
@@ -2,7 +2,6 @@ using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
-using Avalonia.Controls.Primitives;
 
 namespace Ursa.Controls;
 
@@ -10,7 +9,6 @@ namespace Ursa.Controls;
 public class ClosableTag : ContentControl
 {
     public const string PART_CloseButton = "PART_CloseButton";
-    private Button? _closeButton;
 
     public static readonly StyledProperty<ICommand?> CommandProperty = AvaloniaProperty.Register<ClosableTag, ICommand?>(
         nameof(Command));
@@ -19,11 +17,5 @@ public class ClosableTag : ContentControl
     {
         get => GetValue(CommandProperty);
         set => SetValue(CommandProperty, value);
-    }
-
-    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
-    {
-        base.OnApplyTemplate(e);
-        _closeButton = e.NameScope.Find<Button>(PART_CloseButton);
     }
 }

--- a/src/Ursa/Controls/TagInput/ClosableTag.cs
+++ b/src/Ursa/Controls/TagInput/ClosableTag.cs
@@ -8,10 +8,11 @@ using Avalonia.Input;
 namespace Ursa.Controls;
 
 [TemplatePart(PART_CloseButton, typeof(PathIcon))]
-public class ClosableTag: ContentControl
+public class ClosableTag : ContentControl
 {
     public const string PART_CloseButton = "PART_CloseButton";
     private PathIcon? _icon;
+
     public static readonly StyledProperty<ICommand?> CommandProperty = AvaloniaProperty.Register<ClosableTag, ICommand?>(
         nameof(Command));
 
@@ -24,21 +25,21 @@ public class ClosableTag: ContentControl
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
-        if (_icon != null)
+        if (_icon is not null)
         {
-            _icon.PointerPressed -= OnPointerPressed;
+            _icon.PointerReleased -= OnPointerReleased;
         }
+
         _icon = e.NameScope.Find<PathIcon>(PART_CloseButton);
-        if (_icon != null)
+        if (_icon is not null)
         {
-            _icon.PointerPressed += OnPointerPressed;
+            _icon.PointerReleased += OnPointerReleased;
         }
-        
     }
 
-    private void OnPointerPressed(object? sender, PointerPressedEventArgs args)
+    private void OnPointerReleased(object? sender, PointerReleasedEventArgs args)
     {
-        if (Command != null && Command.CanExecute(null))
+        if (Command is not null && Command.CanExecute(null))
         {
             Command.Execute(this);
         }

--- a/src/Ursa/Controls/TagInput/ClosableTag.cs
+++ b/src/Ursa/Controls/TagInput/ClosableTag.cs
@@ -3,15 +3,14 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Metadata;
 using Avalonia.Controls.Primitives;
-using Avalonia.Input;
 
 namespace Ursa.Controls;
 
-[TemplatePart(PART_CloseButton, typeof(PathIcon))]
+[TemplatePart(PART_CloseButton, typeof(Button))]
 public class ClosableTag : ContentControl
 {
     public const string PART_CloseButton = "PART_CloseButton";
-    private PathIcon? _icon;
+    private Button? _closeButton;
 
     public static readonly StyledProperty<ICommand?> CommandProperty = AvaloniaProperty.Register<ClosableTag, ICommand?>(
         nameof(Command));
@@ -25,23 +24,6 @@ public class ClosableTag : ContentControl
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);
-        if (_icon is not null)
-        {
-            _icon.PointerReleased -= OnPointerReleased;
-        }
-
-        _icon = e.NameScope.Find<PathIcon>(PART_CloseButton);
-        if (_icon is not null)
-        {
-            _icon.PointerReleased += OnPointerReleased;
-        }
-    }
-
-    private void OnPointerReleased(object? sender, PointerReleasedEventArgs args)
-    {
-        if (Command is not null && Command.CanExecute(null))
-        {
-            Command.Execute(this);
-        }
+        _closeButton = e.NameScope.Find<Button>(PART_CloseButton);
     }
 }


### PR DESCRIPTION
This pull request updates the `ClosableTag` component in the `TagInput` control to improve its design and functionality. The key changes include replacing the `PathIcon` close button with a `Button`, updating styles for hover and pressed states, and simplifying the command handling logic.

### Design and UI Improvements:
* Added a design preview for the `ClosableTag` component in `TagInput.axaml` to enhance development and visualization. (`src/Ursa.Themes.Semi/Controls/TagInput.axaml`, [src/Ursa.Themes.Semi/Controls/TagInput.axamlR5-R7](diffhunk://#diff-7bf2b0913edfb47d9c1876cb791fa8a4d22fe01b330436a16f1fb3fc1dba2ac6R5-R7))
* Updated the `ClosableTag` template to replace the `PathIcon` close button with a styled `Button`, improving customization and usability. (`src/Ursa.Themes.Semi/Controls/TagInput.axaml`, [src/Ursa.Themes.Semi/Controls/TagInput.axamlL118-R137](diffhunk://#diff-7bf2b0913edfb47d9c1876cb791fa8a4d22fe01b330436a16f1fb3fc1dba2ac6L118-R137))
* Introduced new styles for the close button to define distinct hover and pressed states, enhancing user interaction feedback. (`src/Ursa.Themes.Semi/Controls/TagInput.axaml`, [src/Ursa.Themes.Semi/Controls/TagInput.axamlR149-R154](diffhunk://#diff-7bf2b0913edfb47d9c1876cb791fa8a4d22fe01b330436a16f1fb3fc1dba2ac6R149-R154))

### Codebase Simplification:
* Changed the `TemplatePart` attribute in `ClosableTag.cs` to reflect the replacement of `PathIcon` with `Button`. (`src/Ursa/Controls/TagInput/ClosableTag.cs`, [src/Ursa/Controls/TagInput/ClosableTag.csL6-R14](diffhunk://#diff-e3f73f5bbf47cd53047005ef0a2a34a5f4509f949553c1394acc5156429d9384L6-R14))
* Simplified the `OnApplyTemplate` method by removing the `PointerPressed` event handling logic, as the `Button` now directly supports commands. (`src/Ursa/Controls/TagInput/ClosableTag.cs`, [src/Ursa/Controls/TagInput/ClosableTag.csL27-R27](diffhunk://#diff-e3f73f5bbf47cd53047005ef0a2a34a5f4509f949553c1394acc5156429d9384L27-R27))