### PR TITLE
Replace outdated converters with new ones in Drawer and PathPicker

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/Drawer.axaml
+++ b/src/Ursa.Themes.Semi/Controls/Drawer.axaml
@@ -1,7 +1,6 @@
 <ResourceDictionary
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:c="clr-namespace:Ursa.Themes.Semi.Converters"
     xmlns:u="https://irihi.tech/ursa"
     xmlns:iri="https://irihi.tech/shared">
     <ControlTheme x:Key="{x:Type u:CustomDrawerControl}" TargetType="u:CustomDrawerControl">
@@ -20,17 +19,17 @@
                     <Border
                         Name="PART_Root"
                         Margin="{TemplateBinding Padding,
-                                                 Converter={x:Static c:ThicknessTakeConverter.Left}}"
+                                                 Converter={iri:ThicknessMixerConverter Left}}"
                         Padding="0"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         Background="{DynamicResource SemiColorBackground2}"
                         BorderThickness="{TemplateBinding BorderThickness,
-                                                          Converter={x:Static c:ThicknessTakeConverter.Left}}"
+                                                          Converter={iri:ThicknessMixerConverter Left}}"
                         Classes="Shadow"
                         ClipToBounds="False"
                         CornerRadius="{TemplateBinding CornerRadius,
-                                                       Converter={x:Static c:CornerRadiusTakeConverter.Left}}"
+                                                       Converter={iri:CornerRadiusMixerConverter Left}}"
                         Focusable="True"
                         IsHitTestVisible="True"
                         Theme="{DynamicResource CardBorder}">
@@ -64,39 +63,39 @@
             </ControlTemplate>
         </Setter>
         <Style Selector="^[Position=Right] /template/ Border#PART_Root">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Left}}" />
-            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={x:Static c:CornerRadiusTakeConverter.Left}}" />
-            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={x:Static c:ThicknessTakeConverter.Left}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Left}}" />
+            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={iri:CornerRadiusMixerConverter Left}}" />
+            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={iri:ThicknessMixerConverter Left}}" />
         </Style>
         <Style Selector="^[Position=Left] /template/ Border#PART_Root">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Right}}" />
-            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={x:Static c:CornerRadiusTakeConverter.Right}}" />
-            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={x:Static c:ThicknessTakeConverter.Right}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Right}}" />
+            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={iri:CornerRadiusMixerConverter Right}}" />
+            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={iri:ThicknessMixerConverter Right}}" />
         </Style>
         <Style Selector="^[Position=Top] /template/ Border#PART_Root">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Bottom}}" />
-            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={x:Static c:CornerRadiusTakeConverter.Bottom}}" />
-            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={x:Static c:ThicknessTakeConverter.Bottom}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Bottom}}" />
+            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={iri:CornerRadiusMixerConverter Bottom}}" />
+            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={iri:ThicknessMixerConverter Bottom}}" />
         </Style>
         <Style Selector="^[Position=Bottom] /template/ Border#PART_Root">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Top}}" />
-            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={x:Static c:CornerRadiusTakeConverter.Top}}" />
-            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={x:Static c:ThicknessTakeConverter.Top}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Top}}" />
+            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={iri:CornerRadiusMixerConverter Top}}" />
+            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={iri:ThicknessMixerConverter Top}}" />
         </Style>
         <Style Selector="^[Position=Top] /template/ u|DialogResizer">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Bottom}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Bottom}}" />
             <Setter Property="ResizeDirection" Value="Bottom" />
         </Style>
         <Style Selector="^[Position=Bottom] /template/ u|DialogResizer">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Top}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Top}}" />
             <Setter Property="ResizeDirection" Value="Top" />
         </Style>
         <Style Selector="^[Position=Left] /template/ u|DialogResizer">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Right}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Right}}" />
             <Setter Property="ResizeDirection" Value="Right" />
         </Style>
         <Style Selector="^[Position=Right] /template/ u|DialogResizer">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Left}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Left}}" />
             <Setter Property="ResizeDirection" Value="Left" />
         </Style>
     </ControlTheme>
@@ -117,17 +116,17 @@
                     <Border
                         Name="PART_Root"
                         Margin="{TemplateBinding Padding,
-                                                 Converter={x:Static c:ThicknessTakeConverter.Left}}"
+                                                 Converter={iri:ThicknessMixerConverter Left}}"
                         Padding="0"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch"
                         Background="{DynamicResource SemiColorBackground2}"
                         BorderThickness="{TemplateBinding BorderThickness,
-                                                          Converter={x:Static c:ThicknessTakeConverter.Left}}"
+                                                          Converter={iri:ThicknessMixerConverter Left}}"
                         Classes="Shadow"
                         ClipToBounds="False"
                         CornerRadius="{TemplateBinding CornerRadius,
-                                                       Converter={x:Static c:CornerRadiusTakeConverter.Left}}"
+                                                       Converter={iri:CornerRadiusMixerConverter Left}}"
                         Focusable="True"
                         IsHitTestVisible="True"
                         Theme="{DynamicResource CardBorder}">
@@ -203,39 +202,39 @@
             <Setter Property="Theme" Value="{DynamicResource SolidButton}" />
         </Style>
         <Style Selector="^[Position=Right] /template/ Border#PART_Root">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Left}}" />
-            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={x:Static c:CornerRadiusTakeConverter.Left}}" />
-            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={x:Static c:ThicknessTakeConverter.Left}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Left}}" />
+            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={iri:CornerRadiusMixerConverter Left}}" />
+            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={iri:ThicknessMixerConverter Left}}" />
         </Style>
         <Style Selector="^[Position=Left] /template/ Border#PART_Root">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Right}}" />
-            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={x:Static c:CornerRadiusTakeConverter.Right}}" />
-            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={x:Static c:ThicknessTakeConverter.Right}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Right}}" />
+            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={iri:CornerRadiusMixerConverter Right}}" />
+            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={iri:ThicknessMixerConverter Right}}" />
         </Style>
         <Style Selector="^[Position=Top] /template/ Border#PART_Root">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Bottom}}" />
-            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={x:Static c:CornerRadiusTakeConverter.Bottom}}" />
-            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={x:Static c:ThicknessTakeConverter.Bottom}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Bottom}}" />
+            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={iri:CornerRadiusMixerConverter Bottom}}" />
+            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={iri:ThicknessMixerConverter Bottom}}" />
         </Style>
         <Style Selector="^[Position=Bottom] /template/ Border#PART_Root">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Top}}" />
-            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={x:Static c:CornerRadiusTakeConverter.Top}}" />
-            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={x:Static c:ThicknessTakeConverter.Top}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Top}}" />
+            <Setter Property="CornerRadius" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=CornerRadius, Converter={iri:CornerRadiusMixerConverter Top}}" />
+            <Setter Property="BorderThickness" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=BorderThickness, Converter={iri:ThicknessMixerConverter Top}}" />
         </Style>
         <Style Selector="^[Position=Top] /template/ u|DialogResizer">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Bottom}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Bottom}}" />
             <Setter Property="ResizeDirection" Value="Bottom" />
         </Style>
         <Style Selector="^[Position=Bottom] /template/ u|DialogResizer">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Top}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Top}}" />
             <Setter Property="ResizeDirection" Value="Top" />
         </Style>
         <Style Selector="^[Position=Left] /template/ u|DialogResizer">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Right}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Right}}" />
             <Setter Property="ResizeDirection" Value="Right" />
         </Style>
         <Style Selector="^[Position=Right] /template/ u|DialogResizer">
-            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={x:Static c:ThicknessTakeConverter.Left}}" />
+            <Setter Property="Margin" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Padding, Converter={iri:ThicknessMixerConverter Left}}" />
             <Setter Property="ResizeDirection" Value="Left" />
         </Style>
     </ControlTheme>

--- a/src/Ursa.Themes.Semi/Controls/PathPicker.axaml
+++ b/src/Ursa.Themes.Semi/Controls/PathPicker.axaml
@@ -1,8 +1,8 @@
 ﻿<ResourceDictionary
     xmlns="https://github.com/avaloniaui"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:converters="clr-namespace:Ursa.Themes.Semi.Converters"
-    xmlns:u="https://irihi.tech/ursa">
+    xmlns:u="https://irihi.tech/ursa"
+    xmlns:iri="https://irihi.tech/shared">
     <Design.PreviewWith>
         <StackPanel Margin="20">
             <u:PathPicker Title="Hello World" Width="300" />
@@ -36,22 +36,22 @@
         <Style Selector="^ /template/ Button#PART_Button">
             <Setter Property="DockPanel.Dock" Value="Right" />
             <Setter Property="VerticalAlignment" Value="Center" />
-            <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={x:Static converters:CornerRadiusTakeConverter.Right}}" />
+            <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={iri:CornerRadiusMixerConverter Right}}" />
             <Setter Property="Margin" Value="1 0 0 0" />
         </Style>
         <Style Selector="^ /template/ TextBox#PART_TextBox">
             <Setter Property="DockPanel.Dock" Value="Left" />
-            <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={x:Static converters:CornerRadiusTakeConverter.Left}}" />
+            <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={iri:CornerRadiusMixerConverter Left}}" />
         </Style>
         <Style Selector="^.Top">
             <Style Selector="^ /template/ Button#PART_Button">
                 <Setter Property="DockPanel.Dock" Value="Top" />
-                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={x:Static converters:CornerRadiusTakeConverter.Top}}" />
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={iri:CornerRadiusMixerConverter Top}}" />
                 <Setter Property="Margin" Value="0 0 0 1" />
             </Style>
             <Style Selector="^ /template/ TextBox#PART_TextBox">
                 <Setter Property="DockPanel.Dock" Value="Bottom" />
-                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={x:Static converters:CornerRadiusTakeConverter.Bottom}}" />
+                <Setter Property="CornerRadius" Value="{TemplateBinding CornerRadius, Converter={iri:CornerRadiusMixerConverter Bottom}}" />
             </Style>
         </Style>
     </ControlTheme>
@@ -87,7 +87,7 @@
                             HorizontalAlignment="Stretch"
                             Content="{TemplateBinding Title}"
                             CornerRadius="{TemplateBinding CornerRadius,
-                                                           Converter={x:Static converters:CornerRadiusTakeConverter.Left}}" />
+                                                           Converter={iri:CornerRadiusMixerConverter Left}}" />
                     </Expander.Header>
                     <ListBox ItemsSource="{TemplateBinding SelectedPaths}" />
                 </Expander>
@@ -108,7 +108,7 @@
                             Margin="1,0,0,0"
                             Background="{DynamicResource ToggleButtonDefaultBackground}"
                             CornerRadius="{TemplateBinding CornerRadius,
-                                                           Converter={x:Static converters:CornerRadiusTakeConverter.Right}}"
+                                                           Converter={iri:CornerRadiusMixerConverter Right}}"
                             DockPanel.Dock="Right"
                             IsChecked="{TemplateBinding IsExpanded,
                                                         Mode=TwoWay}"

--- a/src/Ursa.Themes.Semi/Converters/CornerRadiusTakeConverter.cs
+++ b/src/Ursa.Themes.Semi/Converters/CornerRadiusTakeConverter.cs
@@ -5,6 +5,7 @@ using Avalonia.Data.Converters;
 
 namespace Ursa.Themes.Semi.Converters;
 
+[Obsolete("This converter is deprecated. Use CornerRadiusMixerConverter instead.")]
 public class CornerRadiusTakeConverter: IValueConverter
 {
     private  readonly Dock _dock;

--- a/src/Ursa.Themes.Semi/Converters/ThicknessTakeConverter.cs
+++ b/src/Ursa.Themes.Semi/Converters/ThicknessTakeConverter.cs
@@ -5,6 +5,7 @@ using Avalonia.Data.Converters;
 
 namespace Ursa.Themes.Semi.Converters;
 
+[Obsolete("This converter is deprecated. Use ThicknessMixerConverter instead.")]
 public class ThicknessTakeConverter: IValueConverter
 {
     private readonly Dock _dock;


### PR DESCRIPTION
This pull request refactors the `Drawer.axaml` and `PathPicker.axaml` components to replace deprecated converters with updated ones and marks the old converters as obsolete. These changes improve maintainability by transitioning to the recommended `CornerRadiusMixerConverter` and `ThicknessMixerConverter`.

### Converter Replacement:
* In `src/Ursa.Themes.Semi/Controls/Drawer.axaml`, replaced all instances of `ThicknessTakeConverter` and `CornerRadiusTakeConverter` with `ThicknessMixerConverter` and `CornerRadiusMixerConverter`, respectively. This change affects multiple bindings for properties like `Margin`, `CornerRadius`, and `BorderThickness`. [[1]](diffhunk://#diff-ab71f24aedfaebc0ee8b32c3abe10be88ced64e49f6be3c41a84822ba8263ce4L23-R32) [[2]](diffhunk://#diff-ab71f24aedfaebc0ee8b32c3abe10be88ced64e49f6be3c41a84822ba8263ce4L67-R98) [[3]](diffhunk://#diff-ab71f24aedfaebc0ee8b32c3abe10be88ced64e49f6be3c41a84822ba8263ce4L120-R129) [[4]](diffhunk://#diff-ab71f24aedfaebc0ee8b32c3abe10be88ced64e49f6be3c41a84822ba8263ce4L206-R237)
* Similarly, in `src/Ursa.Themes.Semi/Controls/PathPicker.axaml`, replaced `CornerRadiusTakeConverter` with `CornerRadiusMixerConverter` for bindings related to `CornerRadius`. [[1]](diffhunk://#diff-01f517e3ff5eda50b79d7eeae816d3dc1e601860ddc17a3aa02e8aecf09b59f5L39-R54) [[2]](diffhunk://#diff-01f517e3ff5eda50b79d7eeae816d3dc1e601860ddc17a3aa02e8aecf09b59f5L90-R90) [[3]](diffhunk://#diff-01f517e3ff5eda50b79d7eeae816d3dc1e601860ddc17a3aa02e8aecf09b59f5L111-R111)

### Deprecation of Old Converters:
* Marked `CornerRadiusTakeConverter` in `src/Ursa.Themes.Semi/Converters/CornerRadiusTakeConverter.cs` as obsolete with a message recommending `CornerRadiusMixerConverter`.
* Marked `ThicknessTakeConverter` in `src/Ursa.Themes.Semi/Converters/ThicknessTakeConverter.cs` as obsolete with a message recommending `ThicknessMixerConverter`.