### PR TITLE
NavMenu: SelectionChanging Event

### DIFF
--- a/src/Ursa/Controls/NavMenu/NavMenu.cs
+++ b/src/Ursa/Controls/NavMenu/NavMenu.cs
@@ -191,10 +191,10 @@ public class NavMenu : ItemsControl, ICustomKeyboardNavigation
     }
     
     
-    public static readonly RoutedEvent<SelectionChangedEventArgs> SelectionChangingEvent =
-        RoutedEvent.Register<NavMenu, SelectionChangedEventArgs>(nameof(SelectionChanging), RoutingStrategies.Bubble);
+    public static readonly RoutedEvent<SelectionChangingEventArgs> SelectionChangingEvent =
+        RoutedEvent.Register<NavMenu, SelectionChangingEventArgs>(nameof(SelectionChanging), RoutingStrategies.Bubble);
 
-    public event EventHandler SelectionChanging
+    public event EventHandler<SelectionChangingEventArgs> SelectionChanging
     {
         add => AddHandler(SelectionChangingEvent, value);
         remove => RemoveHandler(SelectionChangingEvent, value);
@@ -512,6 +512,12 @@ public class NavMenu : ItemsControl, ICustomKeyboardNavigation
             Source = this,
         };
         RaiseEvent(args);
-        return args.CanSelect;
+        var result =  args.CanSelect;
+        if (result == false)
+        {
+            var container = GetContainerForItem(SelectedItem);
+            container?.Focus(NavigationMethod.Directional);
+        }
+        return result;
     }
 }

--- a/src/Ursa/Controls/NavMenu/NavMenu.cs
+++ b/src/Ursa/Controls/NavMenu/NavMenu.cs
@@ -189,6 +189,16 @@ public class NavMenu : ItemsControl, ICustomKeyboardNavigation
         add => AddHandler(SelectionChangedEvent, value);
         remove => RemoveHandler(SelectionChangedEvent, value);
     }
+    
+    
+    public static readonly RoutedEvent<SelectionChangedEventArgs> SelectionChangingEvent =
+        RoutedEvent.Register<NavMenu, SelectionChangedEventArgs>(nameof(SelectionChanging), RoutingStrategies.Bubble);
+
+    public event EventHandler SelectionChanging
+    {
+        add => AddHandler(SelectionChangingEvent, value);
+        remove => RemoveHandler(SelectionChangingEvent, value);
+    }
 
     protected override bool NeedsContainerOverride(object? item, int index, out object? recycleKey)
     {
@@ -485,5 +495,23 @@ public class NavMenu : ItemsControl, ICustomKeyboardNavigation
         }
 
         return null;
+    }
+
+    internal bool CanChangeSelection(NavMenuItem item)
+    {
+        object? newSelection = null;
+        if (item.DataContext is not null && item.DataContext != DataContext)
+            newSelection = item.DataContext;
+        else
+            newSelection = item;
+        var args = new SelectionChangingEventArgs(
+            SelectionChangingEvent, 
+            new[] { SelectedItem },
+            new[] { newSelection })
+        {
+            Source = this,
+        };
+        RaiseEvent(args);
+        return args.CanSelect;
     }
 }

--- a/src/Ursa/Controls/NavMenu/NavMenuItem.cs
+++ b/src/Ursa/Controls/NavMenu/NavMenuItem.cs
@@ -381,6 +381,10 @@ public class NavMenuItem : HeaderedItemsControl
 
     internal void SelectItem(NavMenuItem item)
     {
+        if (item == this && RootMenu?.CanChangeSelection(item) != true)
+        {
+            return;
+        }
         SetCurrentValue(IsSelectedProperty, item == this);
         SetCurrentValue(IsHighlightedProperty, true);
 

--- a/src/Ursa/Controls/NavMenu/SelectionChangingEventArgs.cs
+++ b/src/Ursa/Controls/NavMenu/SelectionChangingEventArgs.cs
@@ -6,19 +6,19 @@ namespace Ursa.Controls;
 public class SelectionChangingEventArgs: RoutedEventArgs
 {
     /// <summary>Gets the items that were added to the selection.</summary>
-    public IList AddedItems { get; }
+    public IList NewItems { get; }
 
     /// <summary>Gets the items that were removed from the selection.</summary>
-    public IList RemovedItems { get; }
+    public IList OldItems { get; }
     
     /// <summary>
     /// Gets or sets a value indicating whether the selection can be changed. If set to <c>false</c>, the selection will not change.
     /// </summary>
     public bool CanSelect { get; set; } = true;
     
-    public SelectionChangingEventArgs(RoutedEvent routedEvent, IList removedItems, IList addedItems): base(routedEvent)
+    public SelectionChangingEventArgs(RoutedEvent routedEvent, IList oldItems, IList newItems): base(routedEvent)
     {
-        RemovedItems = removedItems;
-        AddedItems = addedItems;
+        OldItems = oldItems;
+        NewItems = newItems;
     }
 }

--- a/src/Ursa/Controls/NavMenu/SelectionChangingEventArgs.cs
+++ b/src/Ursa/Controls/NavMenu/SelectionChangingEventArgs.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using Avalonia.Interactivity;
+
+namespace Ursa.Controls;
+
+public class SelectionChangingEventArgs: RoutedEventArgs
+{
+    /// <summary>Gets the items that were added to the selection.</summary>
+    public IList AddedItems { get; }
+
+    /// <summary>Gets the items that were removed from the selection.</summary>
+    public IList RemovedItems { get; }
+    
+    /// <summary>
+    /// Gets or sets a value indicating whether the selection can be changed. If set to <c>false</c>, the selection will not change.
+    /// </summary>
+    public bool CanSelect { get; set; } = true;
+    
+    public SelectionChangingEventArgs(RoutedEvent routedEvent, IList removedItems, IList addedItems): base(routedEvent)
+    {
+        RemovedItems = removedItems;
+        AddedItems = addedItems;
+    }
+}

--- a/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/Test.cs
+++ b/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/Test.cs
@@ -1,0 +1,103 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.LogicalTree;
+using Ursa.Controls;
+
+namespace HeadlessTest.Ursa.Controls.NavMenuTests.CanSelectTests;
+
+public class Test
+{
+    [AvaloniaFact]
+    public void CanSelect_Blocks_Selection_Change_Inline_Xaml()
+    {
+        Window window = new Window
+        {
+            Width = 400,
+            Height = 400,
+        };
+
+        var view = new TestView1();
+        
+        window.Content = view;
+        
+        window.Show();
+
+        var menu = view.FindControl<NavMenu>("Menu");
+        var item1 = view.FindControl<NavMenuItem>("MenuItem1");
+        var item2 = view.FindControl<NavMenuItem>("MenuItem2");
+        var item3 = view.FindControl<NavMenuItem>("MenuItem3");
+
+        Assert.NotNull(menu);
+        Assert.NotNull(item1);
+        Assert.NotNull(item2);
+        Assert.NotNull(item3);
+
+        var point1 = item1.TranslatePoint(new Point(0, 0), window);
+        var point2 = item2.TranslatePoint(new Point(0, 0), window);
+        var point3 = item3.TranslatePoint(new Point(0, 0), window);
+        Assert.NotNull(point1);
+        Assert.NotNull(point2);
+        Assert.NotNull(point3);
+        
+        window.MouseDown(new Point(point1.Value.X+10, point1.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        window.MouseUp(new Point(point1.Value.X+10, point1.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        Assert.Equal(item1, menu.SelectedItem);
+        
+        window.MouseDown(new Point(point2.Value.X+10, point2.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        window.MouseUp(new Point(point2.Value.X+10, point2.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        Assert.Equal(item1, menu.SelectedItem); // Should not change selection due to CanSelect being false
+        
+        window.MouseDown(new Point(point3.Value.X+10, point3.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        window.MouseUp(new Point(point3.Value.X+10, point3.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        Assert.Equal(item3, menu.SelectedItem); // Should change selection to item3
+
+    }
+    
+    [AvaloniaFact]
+    public void CanSelect_Blocks_Selection_Change_Inline_Code()
+    {
+        Window window = new Window
+        {
+            Width = 400,
+            Height = 400,
+        };
+
+        var view = new TestView2();
+        
+        window.Content = view;
+        
+        window.Show();
+
+        var menu = view.FindControl<NavMenu>("Menu");
+        var items = menu.GetLogicalDescendants().OfType<NavMenuItem>().ToList();
+        var item1 = items[0];
+        var item2 = items[1];
+        var item3 = items[2];
+
+        Assert.NotNull(menu);
+        Assert.NotNull(item1);
+        Assert.NotNull(item2);
+        Assert.NotNull(item3);
+
+        var point1 = item1.TranslatePoint(new Point(0, 0), window);
+        var point2 = item2.TranslatePoint(new Point(0, 0), window);
+        var point3 = item3.TranslatePoint(new Point(0, 0), window);
+        Assert.NotNull(point1);
+        Assert.NotNull(point2);
+        Assert.NotNull(point3);
+        
+        window.MouseDown(new Point(point1.Value.X+10, point1.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        window.MouseUp(new Point(point1.Value.X+10, point1.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        Assert.Equal(item1.DataContext, menu.SelectedItem);
+        
+        window.MouseDown(new Point(point2.Value.X+10, point2.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        window.MouseUp(new Point(point2.Value.X+10, point2.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        Assert.Equal(item1.DataContext, menu.SelectedItem); // Should not change selection due to CanSelect being false
+        
+        window.MouseDown(new Point(point3.Value.X+10, point3.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        window.MouseUp(new Point(point3.Value.X+10, point3.Value.Y+10), Avalonia.Input.MouseButton.Left);
+        Assert.Equal(item3.DataContext, menu.SelectedItem); // Should change selection to item3
+    }
+}

--- a/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/TestView1.axaml
+++ b/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/TestView1.axaml
@@ -1,0 +1,13 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:u="https://irihi.tech/ursa"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="HeadlessTest.Ursa.Controls.NavMenuTests.CanSelectTests.TestView1">
+    <u:NavMenu Name="Menu" ExpandWidth="400" IsHorizontalCollapsed="False" SelectionChanging="Menu_OnSelectionChanging">
+        <u:NavMenuItem Name="MenuItem1" Header="Item 1" />
+        <u:NavMenuItem Name="MenuItem2" Header="Item 2" />
+        <u:NavMenuItem Name="MenuItem3" Header="Item 3" />
+    </u:NavMenu>
+</UserControl>

--- a/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/TestView1.axaml.cs
+++ b/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/TestView1.axaml.cs
@@ -1,0 +1,23 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using Ursa.Controls;
+
+namespace HeadlessTest.Ursa.Controls.NavMenuTests.CanSelectTests;
+
+public partial class TestView1 : UserControl
+{
+    public TestView1()
+    {
+        InitializeComponent();
+    }
+
+    private void Menu_OnSelectionChanging(object? sender, SelectionChangingEventArgs e)
+    {
+        var newItem = e.NewItems;
+        if (newItem is [NavMenuItem { Name: "MenuItem2" }])
+        {
+            e.CanSelect = false; // Prevent selection change for MenuItem2
+        }
+    }
+}

--- a/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/TestView2.axaml
+++ b/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/TestView2.axaml
@@ -1,0 +1,12 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:u="https://irihi.tech/ursa"
+             xmlns:canSelectTests="clr-namespace:HeadlessTest.Ursa.Controls.NavMenuTests.CanSelectTests"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:DataType="canSelectTests:TestView2ViewModel"
+             x:CompileBindings="True"
+             x:Class="HeadlessTest.Ursa.Controls.NavMenuTests.CanSelectTests.TestView2">
+    <u:NavMenu Name="Menu" ItemsSource="{Binding  MenuItems}" SelectionChanging="NavMenu_OnSelectionChanging"/>
+</UserControl>

--- a/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/TestView2.axaml.cs
+++ b/tests/HeadlessTest.Ursa/Controls/NavMenuTests/CanSelectTests/TestView2.axaml.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.ObjectModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using CommunityToolkit.Mvvm.ComponentModel;
+using Ursa.Controls;
+
+namespace HeadlessTest.Ursa.Controls.NavMenuTests.CanSelectTests;
+
+public partial class TestView2 : UserControl
+{
+    public TestView2()
+    {
+        InitializeComponent();
+        this.DataContext = new TestView2ViewModel();
+    }
+
+    private void NavMenu_OnSelectionChanging(object? sender, SelectionChangingEventArgs e)
+    {
+        if (e.NewItems is [MenuItemViewModel item])
+        {
+            if (item.Text.Contains("2"))
+            {
+                e.CanSelect = false;
+            }
+        }
+    }
+}
+
+public partial class TestView2ViewModel
+{
+    public ObservableCollection<MenuItemViewModel> MenuItems { get; } = new()
+    {
+        new MenuItemViewModel { Text = "Menu Item 1" },
+        new MenuItemViewModel { Text = "Menu Item 2" },
+        new MenuItemViewModel { Text = "Menu Item 3" }
+    };
+}
+
+public partial class MenuItemViewModel: ObservableObject
+{
+    [ObservableProperty] private string? _text;
+}


### PR DESCRIPTION
In reality, `NavMenu` selection change means a heavy page toggle task. It is necessary to check whether the operation from UI is intended, and stop the change in advance. 

This pull request introduces a new `SelectionChanging` event in the `NavMenu` control, enabling finer control over selection changes. It also adds logic to handle scenarios where a selection change might be prevented. The changes include defining the event, implementing the supporting logic, and creating a new class for event arguments.

### How to use

User can subscribe to `SelectionChanging` event, this event happens before real selection change starts. User can check the current state of your application. if you want to stop the selection change, you can set `e.CanSelect` to false, and the selection change won't happen.

Notice that this only prevents selection change from UI (by pointer or keyboard). When user assign a new item to `NavMenu.SelectedItem`, it naturally can be checked from ViewModel or code behind. User should stop the assignment on their own manner. 
