### PR TITLE
enhance Publish & Release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,110 +3,165 @@ name: Publish Demo
 on:
   workflow_dispatch:
     inputs:
-      platform:
-        description: 'Platform to publish'
-        required: true
-        default: 'all'
-        type: choice
-        options:
-          - 'windows'
-          - 'linux'
-          - 'android'
-          - 'all'
-      win64:
+      win-x64:
         description: 'Windows x64'
         required: true
-        default: true
+        default: false
         type: boolean
-      win64_aot:
+      win-x64-aot:
         description: 'Windows x64 AOT'
         required: true
-        default: true
+        default: false
+        type: boolean
+      linux-x64:
+        description: 'Linux x64'
+        required: true
+        default: false
+        type: boolean
+      linux-x64-aot:
+        description: 'Linux x64 AOT'
+        required: true
+        default: false
+        type: boolean
+      osx-arm64:
+        description: 'macOS arm64'
+        required: true
+        default: false
+        type: boolean
+      osx-arm64-aot:
+        description: 'macOS arm64 AOT'
+        required: true
+        default: false
+        type: boolean
+      android-arm64:
+        description: 'Android arm64'
+        required: true
+        default: false
         type: boolean
 
 jobs:
-  windows:
-    if: ${{ github.event.inputs.platform == 'windows' || github.event.inputs.platform == 'all' }}
+  win-x64:
+    if: ${{ github.event.inputs.win-x64 == 'true' }}
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
-
-      - name: Make upload directory
-        run: mkdir upload
-
+        uses: actions/checkout@v4.2.2
       - name: Publish win-x64
-        if: ${{ github.event.inputs.win64 == 'true' }}
-        run: dotnet publish demo/Ursa.Demo.Desktop -r win-x64 -c Release -o publish/win64 --sc /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+        run: dotnet publish demo/Ursa.Demo.Desktop -r win-x64 -c Release -o publish --sc -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Ursa.Demo.Desktop.win-x64
+          path: |
+            publish
+            !publish/*.pdb
 
-      - name: Zip win-x64
-        if: ${{ github.event.inputs.win64 == 'true' }}
-        run: |
-          $files = Get-ChildItem -Path publish/win64/* -Recurse -Exclude *.pdb
-          Compress-Archive -Path $files.FullName -DestinationPath upload/Ursa.Demo.Desktop.win-x64.zip
-
+  win-x64-aot:
+    if: ${{ github.event.inputs.win-x64-aot == 'true' }}
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
       - name: Enable Native AOT in .csproj
-        if: ${{ github.event.inputs.win64_aot == 'true' }}
         run: |
           sed -i 's#<!--<PublishAot>true</PublishAot>-->#<PublishAot>true</PublishAot>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
           sed -i 's#<!--<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>-->#<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
-
       - name: Publish win-x64 AOT
-        if: ${{ github.event.inputs.win64_aot == 'true' }}
-        run: dotnet publish demo/Ursa.Demo.Desktop -r win-x64 -c Release -o publish/win64-aot
-
-      - name: Zip win-x64 AOT
-        if: ${{ github.event.inputs.win64_aot == 'true' }}
-        run: |
-          $files = Get-ChildItem -Path publish/win64-aot/* -Recurse -Exclude *.pdb
-          Compress-Archive -Path $files.FullName -DestinationPath upload/Ursa.Demo.Desktop.win-x64.NativeAOT.zip
-
+        run: dotnet publish demo/Ursa.Demo.Desktop -r win-x64 -c Release -o publish
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.6.2
         with:
-          name: windows
-          path: upload
+          name: Ursa.Demo.Desktop.win-x64.NativeAOT
+          path: |
+            publish
+            !publish/*.pdb
 
-  linux:
-    if: ${{ github.event.inputs.platform == 'linux' || github.event.inputs.platform == 'all' }}
+  linux-x64:
+    if: ${{ github.event.inputs.linux-x64 == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
-
-      - name: Make upload directory
-        run: mkdir upload
-
+        uses: actions/checkout@v4.2.2
       - name: Publish linux-x64
-        run: dotnet publish demo/Ursa.Demo.Desktop -r linux-x64 -c Release -o publish/linux64 --sc /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
-
-      - name: Zip linux-x64
-        run: zip -j -r upload/Ursa.Demo.Desktop.linux-x64.zip publish/linux64 -x "*.pdb"
-
+        run: dotnet publish demo/Ursa.Demo.Desktop -r linux-x64 -c Release -o publish --sc -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.6.2
         with:
-          name: linux
-          path: upload
+          name: Ursa.Demo.Desktop.linux-x64
+          path: |
+            publish
+            !publish/*.pdb
 
-  android:
-    if: ${{ github.event.inputs.platform == 'android' || github.event.inputs.platform == 'all' }}
+  linux-x64-aot:
+    if: ${{ github.event.inputs.linux-x64-aot == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Enable Native AOT in .csproj
+        run: |
+          sed -i 's#<!--<PublishAot>true</PublishAot>-->#<PublishAot>true</PublishAot>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
+          sed -i 's#<!--<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>-->#<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
+      - name: Publish linux-x64 AOT
+        run: dotnet publish demo/Ursa.Demo.Desktop -r linux-x64 -c Release -o publish
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Ursa.Demo.Desktop.linux-x64.NativeAOT
+          path: |
+            publish
+            !publish/*.pdb
+
+  osx-arm64:
+    if: ${{ github.event.inputs.osx-arm64 == 'true' }}
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Publish osx-arm64
+        run: dotnet publish demo/Ursa.Demo.Desktop -r osx-arm64 -c Release -o publish --sc -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Ursa.Demo.Desktop.osx-arm64
+          path: |
+            publish
+            !publish/*.pdb
+
+  osx-arm64-aot:
+    if: ${{ github.event.inputs.osx-arm64-aot == 'true' }}
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Enable Native AOT in .csproj
+        run: |
+          sed -i '' 's#<!--<PublishAot>true</PublishAot>-->#<PublishAot>true</PublishAot>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
+          sed -i '' 's#<!--<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>-->#<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
+      - name: Publish osx-arm64 AOT
+        run: dotnet publish demo/Ursa.Demo.Desktop -r osx-arm64 -c Release -o publish
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Ursa.Demo.Desktop.osx-arm64.NativeAOT
+          path: |
+            publish
+            !publish/*.pdb
+
+  android-arm64:
+    if: ${{ github.event.inputs.android-arm64 == 'true' }}
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
-
+        uses: actions/checkout@v4.2.2
       - name: CD Android
         run: cd demo/Ursa.Demo.Android
-
       - name: Restore Dependencies
         run: dotnet restore
-
       - name: Publish Android
         run: dotnet publish demo/Ursa.Demo.Android -c Release -f net8.0-android --no-restore -o publish -p:RuntimeIdentifier=android-arm64
-
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.6.2
         with:
-          name: android
+          name: android-arm64
           path: publish/*Signed.apk

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,134 +7,176 @@ on:
   workflow_dispatch:
 
 jobs:
-  pack:
+  nuget:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Pack Ursa
         run: dotnet pack src/Ursa -o nugets
-
       - name: Pack Ursa.Themes.Semi
         run: dotnet pack src/Ursa.Themes.Semi -o nugets
 
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: nugets
           path: nugets
 
-  publish-windows:
+  win-x64:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Make upload directory
-        run: mkdir upload
-
+        uses: actions/checkout@v4.2.2
       - name: Publish win-x64
-        run: dotnet publish demo/Ursa.Demo.Desktop -r win-x64 -c Release -o publish/win64 --sc /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
+        run: dotnet publish demo/Ursa.Demo.Desktop -r win-x64 -c Release -o publish --sc -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Ursa.Demo.Desktop.win-x64
+          path: |
+            publish
+            !publish/*.pdb
 
-      - name: Zip win-x64
-        run: |
-          $files = Get-ChildItem -Path publish/win64/* -Recurse -Exclude *.pdb
-          Compress-Archive -Path $files.FullName -DestinationPath upload/Ursa.Demo.Desktop.win-x64.zip
-
+  win-x64-aot:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
       - name: Enable Native AOT in .csproj
         run: |
           sed -i 's#<!--<PublishAot>true</PublishAot>-->#<PublishAot>true</PublishAot>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
           sed -i 's#<!--<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>-->#<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
-
       - name: Publish win-x64 AOT
-        run: dotnet publish demo/Ursa.Demo.Desktop -r win-x64 -c Release -o publish/win64-aot
-
-      - name: Zip win-x64 AOT
-        run: |
-          $files = Get-ChildItem -Path publish/win64-aot/* -Recurse -Exclude *.pdb
-          Compress-Archive -Path $files.FullName -DestinationPath upload/Ursa.Demo.Desktop.win-x64.NativeAOT.zip
-
+        run: dotnet publish demo/Ursa.Demo.Desktop -r win-x64 -c Release -o publish
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
-          name: windows
-          path: upload
+          name: Ursa.Demo.Desktop.win-x64.NativeAOT
+          path: |
+            publish
+            !publish/*.pdb
 
-  publish-linux:
+  linux-x64:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Make upload directory
-        run: mkdir upload
-
+        uses: actions/checkout@v4.2.2
       - name: Publish linux-x64
-        run: dotnet publish demo/Ursa.Demo.Desktop -r linux-x64 -c Release -o publish/linux64 --sc /p:PublishSingleFile=true /p:IncludeNativeLibrariesForSelfExtract=true
-
-      - name: Zip linux-x64
-        run: zip -j -r upload/Ursa.Demo.Desktop.linux-x64.zip publish/linux64 -x "*.pdb"
-
+        run: dotnet publish demo/Ursa.Demo.Desktop -r linux-x64 -c Release -o publish --sc -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
-          name: linux
-          path: upload
+          name: Ursa.Demo.Desktop.linux-x64
+          path: |
+            publish
+            !publish/*.pdb
 
-  publish-android:
+  linux-x64-aot:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Enable Native AOT in .csproj
+        run: |
+          sed -i 's#<!--<PublishAot>true</PublishAot>-->#<PublishAot>true</PublishAot>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
+          sed -i 's#<!--<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>-->#<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
+      - name: Publish linux-x64 AOT
+        run: dotnet publish demo/Ursa.Demo.Desktop -r linux-x64 -c Release -o publish
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Ursa.Demo.Desktop.linux-x64.NativeAOT
+          path: |
+            publish
+            !publish/*.pdb
+
+  osx-arm64:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Publish osx-arm64
+        run: dotnet publish demo/Ursa.Demo.Desktop -r osx-arm64 -c Release -o publish --sc -p:PublishSingleFile=true -p:IncludeNativeLibrariesForSelfExtract=true
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Ursa.Demo.Desktop.osx-arm64
+          path: |
+            publish
+            !publish/*.pdb
+
+  osx-arm64-aot:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.2.2
+      - name: Enable Native AOT in .csproj
+        run: |
+          sed -i '' 's#<!--<PublishAot>true</PublishAot>-->#<PublishAot>true</PublishAot>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
+          sed -i '' 's#<!--<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>-->#<IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>#' demo/Ursa.Demo.Desktop/Ursa.Demo.Desktop.csproj
+      - name: Publish osx-arm64 AOT
+        run: dotnet publish demo/Ursa.Demo.Desktop -r osx-arm64 -c Release -o publish
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: Ursa.Demo.Desktop.osx-arm64.NativeAOT
+          path: |
+            publish
+            !publish/*.pdb
+
+  android-arm64:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
+        uses: actions/checkout@v4.2.2
       - name: CD Android
         run: cd demo/Ursa.Demo.Android
-
       - name: Restore Dependencies
         run: dotnet restore
-
       - name: Publish Android
         run: dotnet publish demo/Ursa.Demo.Android -c Release -f net8.0-android --no-restore -o publish -p:RuntimeIdentifier=android-arm64
-
       - name: Upload a Build Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
-          name: android
+          name: android-arm64
           path: publish/*Signed.apk
 
   draft-release:
-    needs: [ pack, publish-windows, publish-linux, publish-android ]
+    needs: [
+      nuget,
+      win-x64,win-x64-aot,
+      linux-x64,linux-x64-aot,
+      osx-arm64,osx-arm64-aot,
+      android-arm64
+    ]
     runs-on: ubuntu-latest
     steps:
-      - name: Download nugets Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: nugets
+      - uses: actions/download-artifact@v4.3.0
 
-      - name: Download windows Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: windows
+      - name: Display structure of downloaded files
+        run: ls -R
 
-      - name: Download linux Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: linux
+      - name: Zip artifacts
+        run: |
+          zip -rj Ursa.Demo.Desktop.win-x64.zip Ursa.Demo.Desktop.win-x64
+          zip -rj Ursa.Demo.Desktop.win-x64.NativeAOT.zip Ursa.Demo.Desktop.win-x64.NativeAOT
+          zip -rj Ursa.Demo.Desktop.linux-x64.zip Ursa.Demo.Desktop.linux-x64
+          zip -rj Ursa.Demo.Desktop.linux-x64.NativeAOT.zip Ursa.Demo.Desktop.linux-x64.NativeAOT
+          zip -rj Ursa.Demo.Desktop.osx-arm64.zip Ursa.Demo.Desktop.osx-arm64
+          cd Ursa.Demo.Desktop.osx-arm64.NativeAOT
+          zip -r ../Ursa.Demo.Desktop.osx-arm64.NativeAOT.zip .
 
-      - name: Download android Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: android
+      - name: Display structure of zipped files
+        run: ls -R
 
       - name: Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.3.2
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
         with:
           generate_release_notes: true
           draft: true
           files: |
-            *.nupkg
+            nugets/*.nupkg
+            android-arm64/*.apk
             *.zip
-            *.apk


### PR DESCRIPTION
This pull request refactors and enhances the workflows for publishing and releasing builds across multiple platforms in `.github/workflows/publish.yml` and `.github/workflows/release-tag.yml`. Key changes include replacing platform-based inputs with specific architecture-based inputs, updating dependencies, and improving artifact handling.

### Workflow Input and Job Refactoring:
* Refactored platform inputs (`platform`) to architecture-specific inputs (`win-x64`, `linux-x64`, `osx-arm64`, etc.) for better granularity in build configuration. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L6-R166) [[2]](diffhunk://#diff-78ca2a162e43bc38ce9cf9eee54d1bfa9b15678fcc153cc554779bbb854b3a81L10-L140)
* Reorganized jobs to align with the new architecture-specific inputs, ensuring each job targets a specific platform and architecture (e.g., `win-x64`, `linux-x64-aot`). [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L6-R166) [[2]](diffhunk://#diff-78ca2a162e43bc38ce9cf9eee54d1bfa9b15678fcc153cc554779bbb854b3a81L10-L140)

### Dependency Updates:
* Updated `actions/checkout` to version `v4.2.2` and `actions/upload-artifact` to version `v4.6.2` for improved performance and compatibility. [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L6-R166) [[2]](diffhunk://#diff-78ca2a162e43bc38ce9cf9eee54d1bfa9b15678fcc153cc554779bbb854b3a81L10-L140)

### Artifact Handling Improvements:
* Simplified artifact upload by removing intermediate directories and directly uploading build outputs while excluding unnecessary files (e.g., `.pdb`). [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L6-R166) [[2]](diffhunk://#diff-78ca2a162e43bc38ce9cf9eee54d1bfa9b15678fcc153cc554779bbb854b3a81L10-L140)
* Enhanced artifact zipping and naming conventions for better organization and clarity in release artifacts.

### Release Workflow Enhancements:
* Updated the `draft-release` job to include all architecture-specific jobs as dependencies and streamlined artifact downloading and zipping processes.
* Improved release file structure and added support for generating release notes using `softprops/action-gh-release@v2.3.2`.