### PR TITLE
Fix: ensure FormItem container respects item's IsVisibleProperty

### DIFF
--- a/src/Ursa/Controls/Form/Form.cs
+++ b/src/Ursa/Controls/Form/Form.cs
@@ -76,6 +76,7 @@ public class Form: ItemsControl
             [!FormItem.LabelProperty] = control[!FormItem.LabelProperty],
             [!FormItem.IsRequiredProperty] = control[!FormItem.IsRequiredProperty],
             [!FormItem.NoLabelProperty] = control[!FormItem.NoLabelProperty],
+            [!FormItem.IsVisibleProperty] = control[!IsVisibleProperty],
         };
     }
 


### PR DESCRIPTION
This PR addresses an inconsistency in the visibility behavior of items wrapped by `FormItem` within a `Form` control.

## Problem

When a non-FormItem control is added to a `Form`, it is automatically wrapped in a `FormItem` container. However, the `Label` inside this container does not bind to the item's `IsVisibleProperty`. As a result, even when the item is hidden (IsVisible = false), the label remains visible, which violates the expected semantics of `IsVisibleProperty`.

## Solution

This PR enhances the `CreateContainerForItemOverride` method by binding the container's `IsVisibleProperty `to the item's `IsVisibleProperty`. This ensures that the entire container, including its label, correctly reflects the visibility state of the item.

## Test

```
<u:Form
    LabelAlignment="Right"
    LabelPosition="Left"
    LabelWidth="240">
    <CheckBox IsChecked="{Binding #hiddenInput.IsVisible}" />
    <TextBox
        x:Name="hiddenInput"
        Width="300"
        u:FormItem.Label="HiddenInput" />
    <TextBox
        Width="300"
        u:FormItem.Label="Input" />
</u:Form>
```