### PR TITLE
Fix Ursa.ReactiveUIExtension dependency version and project target framework recognition

### DIFF
--- a/src/Ursa.ReactiveUIExtension/Ursa.ReactiveUIExtension.csproj
+++ b/src/Ursa.ReactiveUIExtension/Ursa.ReactiveUIExtension.csproj
@@ -21,7 +21,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia.ReactiveUI" Version="$(AvaloniaVersion)"/>
+        <PackageReference Include="Avalonia.ReactiveUI" Version="11.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Ursa/Ursa.csproj
+++ b/src/Ursa/Ursa.csproj
@@ -3,7 +3,7 @@
     <Import Project="../Package.props"/>
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;net8</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>


### PR DESCRIPTION

This PR addresses two issues:
1.  **Fix Ursa.ReactiveUIExtension dependency version issue:** Resolves problems related to the dependency version requirements for Ursa.ReactiveUIExtension.
2.  **Fix Ursa target framework recognition issue:** Corrects an issue where the target framework for Ursa could not be recognized in certain development environments.