### PR TITLE
增强 OverlayDialog 和 NumPad 的功能与交互体验

### DIFF
--- a/src/Ursa/Controls/Dialog/Options/OverlayDialogOptions.cs
+++ b/src/Ursa/Controls/Dialog/Options/OverlayDialogOptions.cs
@@ -66,4 +66,8 @@ public class OverlayDialogOptions
     public bool CanResize { get; set; }
     
     public string? StyleClass { get; set; }
+
+    /// <summary>
+    /// </summary>
+    internal Delegate? OnDialogControlClosed { set; get; }
 }

--- a/src/Ursa/Controls/Dialog/OverlayDialog.cs
+++ b/src/Ursa/Controls/Dialog/OverlayDialog.cs
@@ -34,10 +34,22 @@ public static class OverlayDialog
             DataContext = vm,
         };
         ConfigureDefaultDialogControl(t, options);
+
+        if (options?.OnDialogControlClosed != null)
+        {
+            t.AddHandler(OverlayShared.OverlayFeedbackElement.ClosedEvent, options.OnDialogControlClosed);
+
+            t.AddHandler(OverlayShared.OverlayFeedbackElement.ClosedEvent, (s,e)=>
+            {
+                if (s is not DialogControlBase control) return;
+                control.RemoveHandler(OverlayShared.OverlayFeedbackElement.ClosedEvent, options.OnDialogControlClosed);
+            });
+        }
+
         host.AddDialog(t);
         
     }
-    
+
     public static void Show(object? vm, string? hostId = null, OverlayDialogOptions? options = null)
     {
         var host = OverlayDialogManager.GetHost(hostId, options?.TopLevelHashCode);

--- a/src/Ursa/Controls/Dialog/OverlayDialog.cs
+++ b/src/Ursa/Controls/Dialog/OverlayDialog.cs
@@ -39,10 +39,10 @@ public static class OverlayDialog
         {
             t.AddHandler(OverlayShared.OverlayFeedbackElement.ClosedEvent, options.OnDialogControlClosed);
 
-            t.AddHandler(OverlayShared.OverlayFeedbackElement.ClosedEvent, (s,e)=>
+            t.AddHandler(OverlayShared.OverlayFeedbackElement.ClosedEvent, (s, _) =>
             {
-                if (s is not DialogControlBase control) return;
-                control.RemoveHandler(OverlayShared.OverlayFeedbackElement.ClosedEvent, options.OnDialogControlClosed);
+                if (s is not DialogControlBase dc) return;
+                dc.RemoveHandler(OverlayShared.OverlayFeedbackElement.ClosedEvent, options.OnDialogControlClosed);
             });
         }
 

--- a/src/Ursa/Controls/NumPad/NumPad.cs
+++ b/src/Ursa/Controls/NumPad/NumPad.cs
@@ -55,7 +55,7 @@ public class NumPad: TemplatedControl
             GotFocusEvent.RemoveHandler(OnTargetGotFocus, input);
         }
     }
-    
+
     private static void OnTargetGotFocus(object? sender, GotFocusEventArgs e)
     {
         if (sender is not InputElement) return;
@@ -75,12 +75,19 @@ public class NumPad: TemplatedControl
             }
             return;
         }
-        var numPad = new NumPad() 
+        var numPad = new NumPad()
         {
             Target = sender as InputElement ,
             _targetInnerText = FindTextBoxInTarget((sender as InputElement)!)
         };
-        OverlayDialog.Show(numPad, new object(), options: new OverlayDialogOptions() { Buttons = DialogButton.None });
+        OverlayDialog.Show(numPad, new object(), options: new OverlayDialogOptions()
+        {
+            Buttons = DialogButton.None,
+            OnDialogControlClosed = (object? ss, object? e) =>
+            {
+                numPad.Target?.Focus();
+            }
+        });
     }
 
     private static readonly Dictionary<Key, string> KeyInputMapping = new()
@@ -138,7 +145,7 @@ public class NumPad: TemplatedControl
         // 如果目标本身就是 TextBox
         if (target is TextBox textBox)
             return textBox;
-        
+
         // 如果目标是 TemplatedControl，并且已经应用了模板
         if (target is TemplatedControl templatedControl && templatedControl.IsInitialized)
         {


### PR DESCRIPTION
新增 OverlayDialogOptions.OnDialogControlClosed 委托属性， 支持自定义对话框关闭事件处理逻辑，并在 OverlayDialog 中
添加了相关事件绑定与解绑逻辑。

调整 NumPad 的显示与交互逻辑，确保在数字键盘关闭后，
目标输入控件能够重新获取焦点，优化用户体验。