### PR TITLE
修复 PrismDialogDemo

### DIFF
--- a/demo/Ursa.PrismDialogDemo/App.axaml
+++ b/demo/Ursa.PrismDialogDemo/App.axaml
@@ -1,12 +1,14 @@
-<Application xmlns="https://github.com/avaloniaui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:u-semi="https://irihi.tech/ursa/themes/semi"
-             x:Class="Ursa.PrismDialogDemo.App"
-             RequestedThemeVariant="Default">
-             <!-- "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options. -->
+<Application
+    x:Class="Ursa.PrismDialogDemo.App"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:semi="https://irihi.tech/semi"
+    xmlns:u-semi="https://irihi.tech/ursa/themes/semi"
+    RequestedThemeVariant="Default">
+    <!--  "Default" ThemeVariant follows system theme variant. "Dark" or "Light" are other available options.  -->
 
     <Application.Styles>
-        <StyleInclude Source="avares://Semi.Avalonia/Themes/Index.axaml" />
-        <u-semi:SemiTheme Locale="zh-CN"/>
+        <semi:SemiTheme Locale="zh-CN" />
+        <u-semi:SemiTheme Locale="zh-CN" />
     </Application.Styles>
 </Application>

--- a/demo/Ursa.PrismDialogDemo/Ursa.PrismDialogDemo.csproj
+++ b/demo/Ursa.PrismDialogDemo/Ursa.PrismDialogDemo.csproj
@@ -16,7 +16,7 @@
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)"/>
         <PackageReference Include="Prism.DryIoc.Avalonia" Version="8.1.97.11072" />
-        <PackageReference Include="Semi.Avalonia" Version="11.1.0-rc2.1" />
+		<PackageReference Include="Semi.Avalonia" Version="11.2.1.9" />
     </ItemGroup>
 
 


### PR DESCRIPTION
在 Ursa.PrismDialogDemo.csproj 中：
- 将 Semi.Avalonia 包版本从 11.1.0-rc2.1 升级到 11.2.1.9。