### PR TITLE
fix: PathPicker's File Filtering Function malfunctions

### DIFF
--- a/src/Ursa/Controls/PathPicker/PathPicker.cs
+++ b/src/Ursa/Controls/PathPicker/PathPicker.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
@@ -222,7 +223,13 @@ public class PathPicker : TemplatedControl
     */
     private static IReadOnlyList<FilePickerFileType>? ParseFileTypes(string str)
     {
-        if (string.IsNullOrWhiteSpace(str)) return null;
+        if (string.IsNullOrWhiteSpace(str)) 
+            return null;
+        
+        var patternsRegex = new Regex(@"^\[(?:[^*.,]+|([^*.,]+(,[^,]+)+))\]$");
+        if(!patternsRegex.IsMatch(str))
+            throw new ArgumentException($"{nameof(str)} Invalid parameter, please refer to the following content: [Name, Pattern], such as [123, .exe, .pdb] or [All][ImageAll][11, *.txt]");
+        
         string[] separatedStrings = ["[", "][", "]"];
         var list = RemoveNewLine(str)
             .Replace(" ", string.Empty)


### PR DESCRIPTION
Regular expression validation for adding parameters; the sample reference content is as follows:

[Name,Pattern] → True
[123,.exe,.pdb] → True
[All] → True
[ImageAll] → True
[11,*.txt] → True
*.123 → False
*.txt → False
.png → False
[*.txt] → False
[.txt] → False
[a] → True
[a,b] → True
[a,b,c] → True
[a,*] → True
[a,.] → True
[*] → False
[.] → False
[a,] → False
[,a] → False
[] → False
[a,b,] → False
[a,,b] → False
[a*b] → False
[a.b] → False