### PR TITLE
Standardize spelling: Grey to Gray

### DIFF
--- a/demo/Ursa.Demo/Pages/AvatarDemo.axaml
+++ b/demo/Ursa.Demo/Pages/AvatarDemo.axaml
@@ -57,7 +57,7 @@
             <u:Avatar Classes="Yellow" />
             <u:Avatar Classes="Amber" />
             <u:Avatar Classes="Orange" />
-            <u:Avatar Classes="Grey" />
+            <u:Avatar Classes="Gray" />
         </StackPanel>
         <StackPanel Orientation="Horizontal">
             <u:Avatar Classes="ExtraExtraSmall" />

--- a/demo/Ursa.Demo/Pages/DialogDemo.axaml
+++ b/demo/Ursa.Demo/Pages/DialogDemo.axaml
@@ -200,7 +200,7 @@
         <Grid Grid.Column="1">
             <Border
                 Background="{DynamicResource SemiColorBackground1}"
-                BorderBrush="{DynamicResource SemiGrey1}"
+                BorderBrush="{DynamicResource SemiGray1}"
                 BorderThickness="1"
                 ClipToBounds="True"
                 CornerRadius="12">

--- a/demo/Ursa.Demo/Pages/DrawerDemo.axaml
+++ b/demo/Ursa.Demo/Pages/DrawerDemo.axaml
@@ -41,7 +41,7 @@
         </u:Form>
         <Grid Grid.Column="1" ClipToBounds="True">
             <Border
-                BorderBrush="{DynamicResource SemiGrey1}"
+                BorderBrush="{DynamicResource SemiGray1}"
                 Background="{DynamicResource SemiColorBackground1}"
                 BorderThickness="1"
                 ClipToBounds="True"

--- a/demo/Ursa.Demo/Pages/DualBadgeDemo.axaml
+++ b/demo/Ursa.Demo/Pages/DualBadgeDemo.axaml
@@ -65,7 +65,7 @@
                 <u:DualBadge Classes="Yellow">Yellow</u:DualBadge>
                 <u:DualBadge Classes="Amber">Amber</u:DualBadge>
                 <u:DualBadge Classes="Orange">Orange</u:DualBadge>
-                <u:DualBadge Classes="Grey">Grey</u:DualBadge>
+                <u:DualBadge Classes="Gray">Gray</u:DualBadge>
             </WrapPanel>
             <WrapPanel>
                 <u:DualBadge Classes="FlatSquare Red">Red</u:DualBadge>
@@ -83,7 +83,7 @@
                 <u:DualBadge Classes="FlatSquare Yellow">Yellow</u:DualBadge>
                 <u:DualBadge Classes="FlatSquare Amber">Amber</u:DualBadge>
                 <u:DualBadge Classes="FlatSquare Orange">Orange</u:DualBadge>
-                <u:DualBadge Classes="FlatSquare Grey">Grey</u:DualBadge>
+                <u:DualBadge Classes="FlatSquare Gray">Gray</u:DualBadge>
             </WrapPanel>
             <WrapPanel>
                 <u:DualBadge Classes="Plastic Red">Red</u:DualBadge>
@@ -101,7 +101,7 @@
                 <u:DualBadge Classes="Plastic Yellow">Yellow</u:DualBadge>
                 <u:DualBadge Classes="Plastic Amber">Amber</u:DualBadge>
                 <u:DualBadge Classes="Plastic Orange">Orange</u:DualBadge>
-                <u:DualBadge Classes="Plastic Grey">Grey</u:DualBadge>
+                <u:DualBadge Classes="Plastic Gray">Gray</u:DualBadge>
             </WrapPanel>
             <WrapPanel>
                 <u:DualBadge Classes="ForTheBadge Red">Red</u:DualBadge>
@@ -119,7 +119,7 @@
                 <u:DualBadge Classes="ForTheBadge Yellow">Yellow</u:DualBadge>
                 <u:DualBadge Classes="ForTheBadge Amber">Amber</u:DualBadge>
                 <u:DualBadge Classes="ForTheBadge Orange">Orange</u:DualBadge>
-                <u:DualBadge Classes="ForTheBadge Grey">Grey</u:DualBadge>
+                <u:DualBadge Classes="ForTheBadge Gray">Gray</u:DualBadge>
             </WrapPanel>
         </StackPanel>
     </ScrollViewer>

--- a/demo/Ursa.Demo/Pages/ElasticWrapPanelDemo.axaml
+++ b/demo/Ursa.Demo/Pages/ElasticWrapPanelDemo.axaml
@@ -124,7 +124,7 @@
                             <Border Background="{DynamicResource SemiYellow5Color}" />
                             <Border Background="{DynamicResource SemiAmber5Color}" />
                             <Border Background="{DynamicResource SemiOrange5Color}" />
-                            <Border Background="{DynamicResource SemiGrey5Color}" />
+                            <Border Background="{DynamicResource SemiGray5Color}" />
                         </u:ElasticWrapPanel>
                     </TabItem>
                     <TabItem Header="Grid Auto">
@@ -150,7 +150,7 @@
                                 <Border Background="{DynamicResource SemiYellow5Color}" />
                                 <Border Background="{DynamicResource SemiAmber5Color}" />
                                 <Border Background="{DynamicResource SemiOrange5Color}" />
-                                <Border Background="{DynamicResource SemiGrey5Color}" />
+                                <Border Background="{DynamicResource SemiGray5Color}" />
                             </u:ElasticWrapPanel>
                             <Border Grid.Row="1" Margin="0,4" Theme="{StaticResource CardBorder}">
                                 <TextBlock Text="This is blank" />
@@ -181,7 +181,7 @@
                                     <Border Background="{DynamicResource SemiYellow5Color}" />
                                     <Border Background="{DynamicResource SemiAmber5Color}" />
                                     <Border Background="{DynamicResource SemiOrange5Color}" />
-                                    <Border Background="{DynamicResource SemiGrey5Color}" />
+                                    <Border Background="{DynamicResource SemiGray5Color}" />
                                 </u:ElasticWrapPanel>
                             </ScrollViewer>
                         </Border>

--- a/demo/Ursa.Demo/Pages/IntroductionDemo.axaml
+++ b/demo/Ursa.Demo/Pages/IntroductionDemo.axaml
@@ -48,7 +48,7 @@
                         Width="600"
                         Height="300"
                         Scale="0.2"
-                        Background="{DynamicResource SemiGrey1Color}"
+                        Background="{DynamicResource SemiGray1Color}"
                         Source="../Assets/IRIHI.png">
                         <u:ImageViewer.Overlayer>
                             <Grid

--- a/demo/Ursa.Demo/Pages/NavMenuDemo.axaml
+++ b/demo/Ursa.Demo/Pages/NavMenuDemo.axaml
@@ -55,9 +55,9 @@
                             ActiveForeground="{DynamicResource SemiBlue5}"
                             ActiveStrokeBrush="{DynamicResource SemiBlue5}"
                             Data="{Binding Converter={StaticResource IconConverter}}"
-                            Foreground="{DynamicResource SemiGrey5}"
+                            Foreground="{DynamicResource SemiGray5}"
                             IsActive="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=u:NavMenuItem}, Path=IsHighlighted, Mode=TwoWay}"
-                            StrokeBrush="{DynamicResource SemiGrey5}" />
+                            StrokeBrush="{DynamicResource SemiGray5}" />
                     </DataTemplate>
                 </u:NavMenu.IconTemplate>
                 <u:NavMenu.Header>
@@ -68,7 +68,7 @@
                             Margin="4 12"
                             Background="Transparent"
                             DockPanel.Dock="Left">
-                            <iri:IrihiLogo Width="32" Fill="{DynamicResource SemiGrey7}" />
+                            <iri:IrihiLogo Width="32" Fill="{DynamicResource SemiGray7}" />
                         </Panel>
                         <TextBlock
                             Grid.Column="1"

--- a/demo/Ursa.Demo/Views/MainView.axaml
+++ b/demo/Ursa.Demo/Views/MainView.axaml
@@ -53,9 +53,9 @@
                                 ActiveForeground="{DynamicResource SemiBlue5}"
                                 ActiveStrokeBrush="{DynamicResource SemiBlue5}"
                                 Data="{Binding Converter={StaticResource IconConverter}}"
-                                Foreground="{DynamicResource SemiGrey5}"
+                                Foreground="{DynamicResource SemiGray5}"
                                 IsActive="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=u:NavMenuItem}, Path=IsHighlighted, Mode=TwoWay}"
-                                StrokeBrush="{DynamicResource SemiGrey5}" />
+                                StrokeBrush="{DynamicResource SemiGray5}" />
                         </DataTemplate>
                     </u:NavMenu.IconTemplate>
                     <u:NavMenu.HeaderTemplate>
@@ -77,7 +77,7 @@
                                 u:NavMenu.CanToggle="True"
                                 Background="Transparent"
                                 DockPanel.Dock="Left">
-                                <iri:IrihiLogo Width="32" Fill="{DynamicResource SemiGrey7}" />
+                                <iri:IrihiLogo Width="32" Fill="{DynamicResource SemiGray7}" />
                             </Panel>
                             <TextBlock
                                 VerticalAlignment="Center"

--- a/src/Ursa.Themes.Semi/Controls/Avatar.axaml
+++ b/src/Ursa.Themes.Semi/Controls/Avatar.axaml
@@ -11,7 +11,7 @@
     </Design.PreviewWith>
     <ControlTheme x:Key="{x:Type u:Avatar}" TargetType="{x:Type u:Avatar}">
         <Setter Property="Foreground" Value="{DynamicResource AvatarForeground}" />
-        <Setter Property="Background" Value="{DynamicResource AvatarGreyBackground}" />
+        <Setter Property="Background" Value="{DynamicResource AvatarGrayBackground}" />
         <Setter Property="FontSize" Value="{DynamicResource AvatarMediumFontSize}" />
         <Setter Property="FontWeight" Value="{DynamicResource AvatarFontWeight}" />
         <Setter Property="Padding" Value="3" />
@@ -105,8 +105,8 @@
         <Style Selector="^.Orange">
             <Setter Property="Background" Value="{DynamicResource AvatarOrangeBackground}" />
         </Style>
-        <Style Selector="^.Grey">
-            <Setter Property="Background" Value="{DynamicResource AvatarGreyBackground}" />
+        <Style Selector="^.Gray">
+            <Setter Property="Background" Value="{DynamicResource AvatarGrayBackground}" />
         </Style>
 
         <Style Selector="^.Square">

--- a/src/Ursa.Themes.Semi/Controls/DualBadge.axaml
+++ b/src/Ursa.Themes.Semi/Controls/DualBadge.axaml
@@ -120,8 +120,8 @@
         <Style Selector="^.Orange">
             <Setter Property="Background" Value="{DynamicResource DualBadgeFlatOrangeBackground}" />
         </Style>
-        <Style Selector="^.Grey">
-            <Setter Property="Background" Value="{DynamicResource DualBadgeFlatGreyBackground}" />
+        <Style Selector="^.Gray">
+            <Setter Property="Background" Value="{DynamicResource DualBadgeFlatGrayBackground}" />
         </Style>
 
         <Style Selector="^.FlatSquare">
@@ -176,8 +176,8 @@
             <Style Selector="^.Orange">
                 <Setter Property="Background" Value="{DynamicResource DualBadgePlasticOrangeBackground}" />
             </Style>
-            <Style Selector="^.Grey">
-                <Setter Property="Background" Value="{DynamicResource DualBadgePlasticGreyBackground}" />
+            <Style Selector="^.Gray">
+                <Setter Property="Background" Value="{DynamicResource DualBadgePlasticGrayBackground}" />
             </Style>
         </Style>
 

--- a/src/Ursa.Themes.Semi/Controls/Timeline.axaml
+++ b/src/Ursa.Themes.Semi/Controls/Timeline.axaml
@@ -110,7 +110,7 @@
             <Setter Property="IsVisible" Value="True" />
         </Style>
         <Style Selector="^:empty-icon[Type=Default] /template/ Ellipse#PART_DefaultIcon">
-            <Setter Property="Fill" Value="{DynamicResource SemiGrey6}" />
+            <Setter Property="Fill" Value="{DynamicResource SemiGray6}" />
         </Style>
         <Style Selector="^:empty-icon[Type=Error] /template/ Ellipse#PART_DefaultIcon">
             <Setter Property="Fill" Value="{DynamicResource SemiRed6}" />

--- a/src/Ursa.Themes.Semi/Themes/Dark/Avatar.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Dark/Avatar.axaml
@@ -15,5 +15,5 @@
     <StaticResource x:Key="AvatarYellowBackground" ResourceKey="SemiYellow3" />
     <StaticResource x:Key="AvatarAmberBackground" ResourceKey="SemiAmber3" />
     <StaticResource x:Key="AvatarOrangeBackground" ResourceKey="SemiOrange3" />
-    <StaticResource x:Key="AvatarGreyBackground" ResourceKey="SemiGrey3" />
+    <StaticResource x:Key="AvatarGrayBackground" ResourceKey="SemiGray3" />
 </ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Themes/Dark/Clock.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Dark/Clock.axaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ClockHandBrush" ResourceKey="SemiColorTertiaryPointerover" />
     <StaticResource x:Key="ClockHourTickForeground" ResourceKey="SemiColorTertiaryPointerover" />
-    <StaticResource x:Key="ClockMinuteTickForeground" ResourceKey="SemiGrey4" />
+    <StaticResource x:Key="ClockMinuteTickForeground" ResourceKey="SemiGray4" />
     <StaticResource x:Key="ClockArborFill" ResourceKey="SemiColorWhite" />
     <StaticResource x:Key="ClockArborStroke" ResourceKey="SemiColorPrimary" />
 </ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Themes/Dark/DualBadge.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Dark/DualBadge.axaml
@@ -3,8 +3,8 @@
     <StaticResource x:Key="DualBadgeDefaultHeaderForeground" ResourceKey="SemiColorWhite" />
     <StaticResource x:Key="DualBadgeDefaultForeground" ResourceKey="SemiColorWhite" />
     <LinearGradientBrush x:Key="DualBadgeDefaultHeaderBackground" StartPoint="0%,0%" EndPoint="0%,100%">
-        <GradientStop Color="{StaticResource SemiGrey3Color}" Offset="0" />
-        <GradientStop Color="{StaticResource SemiGrey2Color}" Offset="1" />
+        <GradientStop Color="{StaticResource SemiGray3Color}" Offset="0" />
+        <GradientStop Color="{StaticResource SemiGray2Color}" Offset="1" />
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="DualBadgeFlatRedBackground" StartPoint="0%,0%" EndPoint="0%,100%">
@@ -67,15 +67,15 @@
         <GradientStop Color="{StaticResource SemiOrange5Color}" Offset="0" />
         <GradientStop Color="{StaticResource SemiOrange4Color}" Offset="1" />
     </LinearGradientBrush>
-    <LinearGradientBrush x:Key="DualBadgeFlatGreyBackground" StartPoint="0%,0%" EndPoint="0%,100%">
-        <GradientStop Color="{StaticResource SemiGrey5Color}" Offset="0" />
-        <GradientStop Color="{StaticResource SemiGrey4Color}" Offset="1" />
+    <LinearGradientBrush x:Key="DualBadgeFlatGrayBackground" StartPoint="0%,0%" EndPoint="0%,100%">
+        <GradientStop Color="{StaticResource SemiGray5Color}" Offset="0" />
+        <GradientStop Color="{StaticResource SemiGray4Color}" Offset="1" />
     </LinearGradientBrush>
 
 
     <LinearGradientBrush x:Key="DualBadgePlasticHeaderBackground" StartPoint="0%,0%" EndPoint="0%,100%">
-        <GradientStop Color="{StaticResource SemiGrey4Color}" Offset="0" />
-        <GradientStop Color="{StaticResource SemiGrey2Color}" Offset="1" />
+        <GradientStop Color="{StaticResource SemiGray4Color}" Offset="0" />
+        <GradientStop Color="{StaticResource SemiGray2Color}" Offset="1" />
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="DualBadgePlasticRedBackground" StartPoint="0%,0%" EndPoint="0%,100%">
@@ -138,8 +138,8 @@
         <GradientStop Color="{StaticResource SemiOrange6Color}" Offset="0" />
         <GradientStop Color="{StaticResource SemiOrange4Color}" Offset="1" />
     </LinearGradientBrush>
-    <LinearGradientBrush x:Key="DualBadgePlasticGreyBackground" StartPoint="0%,0%" EndPoint="0%,100%">
-        <GradientStop Color="{StaticResource SemiGrey6Color}" Offset="0" />
-        <GradientStop Color="{StaticResource SemiGrey4Color}" Offset="1" />
+    <LinearGradientBrush x:Key="DualBadgePlasticGrayBackground" StartPoint="0%,0%" EndPoint="0%,100%">
+        <GradientStop Color="{StaticResource SemiGray6Color}" Offset="0" />
+        <GradientStop Color="{StaticResource SemiGray4Color}" Offset="1" />
     </LinearGradientBrush>
 </ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Themes/Dark/TagInput.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Dark/TagInput.axaml
@@ -1,5 +1,5 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ClosableTagForeground" ResourceKey="SemiColorText0" />
     <StaticResource x:Key="ClosableTagBackground" ResourceKey="SemiColorBackground4" />
-    <SolidColorBrush x:Key="ClosableTagBorder" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
+    <SolidColorBrush x:Key="ClosableTagBorder" Opacity="0.7" Color="{StaticResource SemiGray2Color}" />
 </ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Themes/Light/Avatar.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Light/Avatar.axaml
@@ -15,5 +15,5 @@
     <StaticResource x:Key="AvatarYellowBackground" ResourceKey="SemiYellow3" />
     <StaticResource x:Key="AvatarAmberBackground" ResourceKey="SemiAmber3" />
     <StaticResource x:Key="AvatarOrangeBackground" ResourceKey="SemiOrange3" />
-    <StaticResource x:Key="AvatarGreyBackground" ResourceKey="SemiGrey3" />
+    <StaticResource x:Key="AvatarGrayBackground" ResourceKey="SemiGray3" />
 </ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Themes/Light/Clock.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Light/Clock.axaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ClockHandBrush" ResourceKey="SemiColorTertiaryPointerover" />
     <StaticResource x:Key="ClockHourTickForeground" ResourceKey="SemiColorTertiaryPointerover" />
-    <StaticResource x:Key="ClockMinuteTickForeground" ResourceKey="SemiGrey4" />
+    <StaticResource x:Key="ClockMinuteTickForeground" ResourceKey="SemiGray4" />
     <StaticResource x:Key="ClockArborFill" ResourceKey="SemiColorWhite" />
     <StaticResource x:Key="ClockArborStroke" ResourceKey="SemiColorPrimary" />
 </ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Themes/Light/DualBadge.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Light/DualBadge.axaml
@@ -3,8 +3,8 @@
     <StaticResource x:Key="DualBadgeDefaultHeaderForeground" ResourceKey="SemiColorWhite" />
     <StaticResource x:Key="DualBadgeDefaultForeground" ResourceKey="SemiColorWhite" />
     <LinearGradientBrush x:Key="DualBadgeDefaultHeaderBackground" StartPoint="0%,0%" EndPoint="0%,100%">
-        <GradientStop Color="{StaticResource SemiGrey6Color}" Offset="0" />
-        <GradientStop Color="{StaticResource SemiGrey7Color}" Offset="1" />
+        <GradientStop Color="{StaticResource SemiGray6Color}" Offset="0" />
+        <GradientStop Color="{StaticResource SemiGray7Color}" Offset="1" />
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="DualBadgeFlatRedBackground" StartPoint="0%,0%" EndPoint="0%,100%">
@@ -67,15 +67,15 @@
         <GradientStop Color="{StaticResource SemiOrange4Color}" Offset="0" />
         <GradientStop Color="{StaticResource SemiOrange5Color}" Offset="1" />
     </LinearGradientBrush>
-    <LinearGradientBrush x:Key="DualBadgeFlatGreyBackground" StartPoint="0%,0%" EndPoint="0%,100%">
-        <GradientStop Color="{StaticResource SemiGrey4Color}" Offset="0" />
-        <GradientStop Color="{StaticResource SemiGrey5Color}" Offset="1" />
+    <LinearGradientBrush x:Key="DualBadgeFlatGrayBackground" StartPoint="0%,0%" EndPoint="0%,100%">
+        <GradientStop Color="{StaticResource SemiGray4Color}" Offset="0" />
+        <GradientStop Color="{StaticResource SemiGray5Color}" Offset="1" />
     </LinearGradientBrush>
 
 
     <LinearGradientBrush x:Key="DualBadgePlasticHeaderBackground" StartPoint="0%,0%" EndPoint="0%,100%">
-        <GradientStop Color="{StaticResource SemiGrey6Color}" Offset="0" />
-        <GradientStop Color="{StaticResource SemiGrey8Color}" Offset="1" />
+        <GradientStop Color="{StaticResource SemiGray6Color}" Offset="0" />
+        <GradientStop Color="{StaticResource SemiGray8Color}" Offset="1" />
     </LinearGradientBrush>
 
     <LinearGradientBrush x:Key="DualBadgePlasticRedBackground" StartPoint="0%,0%" EndPoint="0%,100%">
@@ -138,8 +138,8 @@
         <GradientStop Color="{StaticResource SemiOrange4Color}" Offset="0" />
         <GradientStop Color="{StaticResource SemiOrange6Color}" Offset="1" />
     </LinearGradientBrush>
-    <LinearGradientBrush x:Key="DualBadgePlasticGreyBackground" StartPoint="0%,0%" EndPoint="0%,100%">
-        <GradientStop Color="{StaticResource SemiGrey4Color}" Offset="0" />
-        <GradientStop Color="{StaticResource SemiGrey6Color}" Offset="1" />
+    <LinearGradientBrush x:Key="DualBadgePlasticGrayBackground" StartPoint="0%,0%" EndPoint="0%,100%">
+        <GradientStop Color="{StaticResource SemiGray4Color}" Offset="0" />
+        <GradientStop Color="{StaticResource SemiGray6Color}" Offset="1" />
     </LinearGradientBrush>
 </ResourceDictionary>

--- a/src/Ursa.Themes.Semi/Themes/Light/TagInput.axaml
+++ b/src/Ursa.Themes.Semi/Themes/Light/TagInput.axaml
@@ -1,5 +1,5 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StaticResource x:Key="ClosableTagForeground" ResourceKey="SemiColorText0" />
     <StaticResource x:Key="ClosableTagBackground" ResourceKey="SemiColorBackground4" />
-    <SolidColorBrush x:Key="ClosableTagBorder" Opacity="0.7" Color="{StaticResource SemiGrey2Color}" />
+    <SolidColorBrush x:Key="ClosableTagBorder" Opacity="0.7" Color="{StaticResource SemiGray2Color}" />
 </ResourceDictionary>


### PR DESCRIPTION
Some places in the project used `Grey` while others used `Gray`.  
Since in IT the American spelling `Gray` is more common, this PR updates everything to match.  
Just a small cleanup to keep things consistent and easier to read for everyone.

A similar update has been made in the dependent project [here](https://github.com/irihitech/Semi.Avalonia/pull/670) to keep things consistent across projects.