### PR TITLE
Implement JumpTo command and navigate Introduction page after starting app

### DIFF
--- a/demo/Ursa.Demo/App.axaml
+++ b/demo/Ursa.Demo/App.axaml
@@ -5,7 +5,9 @@
     xmlns:semi="https://irihi.tech/semi"
     xmlns:u-semi="https://irihi.tech/ursa/themes/semi"
     xmlns:u="https://irihi.tech/ursa"
-    xmlns:iri="https://irihi.tech/shared">
+    xmlns:iri="https://irihi.tech/shared"
+    xmlns:vm="clr-namespace:Ursa.Demo.ViewModels"
+    x:DataType="vm:ApplicationViewModel">
     <Application.Styles>
         <semi:SemiTheme Locale="zh-CN" />
         <semi:SemiPopupAnimations />
@@ -18,4 +20,12 @@
             </Style>
         </Style>
     </Application.Styles>
+    <NativeMenu.Menu>
+        <NativeMenu>
+            <NativeMenuItem
+                Header="About Us"
+                Command="{Binding JumpToCommand}"
+                CommandParameter="{x:Static vm:MenuKeys.MenuKeyAboutUs}"/>
+        </NativeMenu>
+    </NativeMenu.Menu>
 </Application>

--- a/demo/Ursa.Demo/App.axaml.cs
+++ b/demo/Ursa.Demo/App.axaml.cs
@@ -12,6 +12,7 @@ public partial class App : Application
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
+        DataContext = new ApplicationViewModel();
     }
 
     public override void OnFrameworkInitializationCompleted()

--- a/demo/Ursa.Demo/ViewModels/ApplicationViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/ApplicationViewModel.cs
@@ -1,0 +1,14 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+
+namespace Ursa.Demo.ViewModels;
+
+public partial class ApplicationViewModel : ObservableObject
+{
+    [RelayCommand]
+    private void JumpTo(string header)
+    {
+        WeakReferenceMessenger.Default.Send(header, "JumpTo");
+    }
+}

--- a/demo/Ursa.Demo/ViewModels/MainViewViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/MainViewViewModel.cs
@@ -16,17 +16,12 @@ public partial class MainViewViewModel : ViewModelBase
     public WindowNotificationManager? NotificationManager { get; set; }
     public MenuViewModel Menus { get; set; } = new MenuViewModel();
 
-    private object? _content;
-
-    public object? Content
-    {
-        get => _content;
-        set => SetProperty(ref _content, value);
-    }
+    [ObservableProperty] private object? _content;
 
     public MainViewViewModel()
     {
-        WeakReferenceMessenger.Default.Register<MainViewViewModel, string>(this, OnNavigation);
+        WeakReferenceMessenger.Default.Register<MainViewViewModel, string, string>(this, "JumpTo", OnNavigation);
+        OnNavigation(this, MenuKeys.MenuKeyIntroduction);
     }
 
 

--- a/demo/Ursa.Demo/ViewModels/MenuItemViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/MenuItemViewModel.cs
@@ -32,6 +32,6 @@ public class MenuItemViewModel: ViewModelBase
     private void OnActivate()
     {
         if (IsSeparator || Key is null) return;
-        WeakReferenceMessenger.Default.Send(Key);
+        WeakReferenceMessenger.Default.Send(Key, "JumpTo");
     }
 }


### PR DESCRIPTION
This pull request introduces a new application-wide navigation mechanism using the MVVM Toolkit's messenger system and updates the UI to include a native menu. The most significant changes are the addition of an `ApplicationViewModel` to coordinate navigation, wiring up the DataContext for the application, and refactoring the menu and navigation logic to use named message channels for improved clarity and maintainability.

**Navigation and ViewModel Infrastructure:**

* Added a new `ApplicationViewModel` class with a `JumpToCommand` that sends navigation messages using a named channel ("JumpTo") via `WeakReferenceMessenger`. (`demo/Ursa.Demo/ViewModels/ApplicationViewModel.cs`)
* Set the application's `DataContext` to an instance of `ApplicationViewModel` in `App.axaml.cs`, enabling data binding for commands across the application. (`demo/Ursa.Demo/App.axaml.cs`)
* Updated `MainViewViewModel` to register for navigation messages on the "JumpTo" channel and to initialize the main content on startup. (`demo/Ursa.Demo/ViewModels/MainViewViewModel.cs`)
* Modified `MenuItemViewModel` to send navigation messages on the "JumpTo" channel, ensuring consistent navigation handling. (`demo/Ursa.Demo/ViewModels/MenuItemViewModel.cs`)

**UI and Menu Enhancements:**

* Updated `App.axaml` to declare the `ApplicationViewModel` as the data type and added a native menu that binds its "About Us" item to the new `JumpToCommand`, using a menu key as the command parameter. (`demo/Ursa.Demo/App.axaml`) [[1]](diffhunk://#diff-320d968be331efd695b6dd14eab3ec5082aa3b24d49846c3aae373a199a7367fL8-R10) [[2]](diffhunk://#diff-320d968be331efd695b6dd14eab3ec5082aa3b24d49846c3aae373a199a7367fR23-R30)