### PR TITLE
Dialog 和 OverlayDialog 标题内容区域重叠问题

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/Dialog.axaml
+++ b/src/Ursa.Themes.Semi/Controls/Dialog.axaml
@@ -42,7 +42,7 @@
                                     Grid.RowSpan="2"
                                     HorizontalScrollBarVisibility="{Binding (ScrollViewer.HorizontalScrollBarVisibility), RelativeSource={RelativeSource TemplatedParent}}"
                                     VerticalScrollBarVisibility="{Binding (ScrollViewer.VerticalScrollBarVisibility), RelativeSource={RelativeSource TemplatedParent}}">
-                                    <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}" />
+                                    <ContentPresenter Name="PART_ContentPresenter" Content="{TemplateBinding Content}" Padding="{TemplateBinding ContentMargin}"  />
                                 </ScrollViewer>
                                 <Grid Grid.Row="0" ColumnDefinitions="*, Auto">
                                     <Panel
@@ -50,6 +50,14 @@
                                         Grid.Column="0"
                                         Grid.ColumnSpan="2"
                                         Background="Transparent" />
+                                    <TextBlock
+                                        Grid.Column="0"
+                                        Margin="24,24,0,0"
+                                        FontSize="14"
+                                        FontWeight="{DynamicResource TextBlockTitleFontWeight}"
+                                        Text="{TemplateBinding Title}"
+                                        TextTrimming="CharacterEllipsis"
+                                        TextWrapping="NoWrap" />
                                     <Button
                                         Name="{x:Static u:MessageBoxWindow.PART_CloseButton}"
                                         Grid.Column="1"
@@ -470,7 +478,8 @@
                             <ContentPresenter
                                 Grid.Row="0"
                                 Grid.RowSpan="2"
-                                Content="{TemplateBinding Content}" />
+                                Content="{TemplateBinding Content}" 
+                                Padding="{TemplateBinding ContentMargin}"  />
                             <Grid Grid.Row="0" ColumnDefinitions="*, Auto">
                                 <Panel
                                     Name="{x:Static u:DialogWindow.PART_TitleArea}"

--- a/src/Ursa/Controls/Dialog/CustomDialogControl.cs
+++ b/src/Ursa/Controls/Dialog/CustomDialogControl.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls.Primitives;
+﻿using Avalonia;
+using Avalonia.Controls.Primitives;
 using Irihi.Avalonia.Shared.Contracts;
 using Irihi.Avalonia.Shared.Helpers;
 
@@ -6,6 +7,40 @@ namespace Ursa.Controls;
 
 public class CustomDialogControl : DialogControlBase
 {
+    
+    public static readonly StyledProperty<Thickness> ContentMarginProperty =
+        AvaloniaProperty.Register<CustomDialogControl, Thickness>(
+            nameof(ContentMargin),
+            new Thickness(0)
+        );
+    public Thickness ContentMargin
+    {
+        get => GetValue(ContentMarginProperty);
+        set => SetValue(ContentMarginProperty, value);
+    }
+    
+    public static readonly StyledProperty<string> TitleProperty =
+        AvaloniaProperty.Register<CustomDialogControl, string>(
+            nameof(ContentMargin),
+            string.Empty
+        );
+    public string Title
+    {
+        get => GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+    
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == TitleProperty)
+        {
+            ContentMargin = string.IsNullOrWhiteSpace(Title)
+                ? new Thickness(0,0,0,0)
+                : new Thickness(0,48,0,0); 
+        }
+    }
+
     protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
     {
         base.OnApplyTemplate(e);

--- a/src/Ursa/Controls/Dialog/DialogWindow.cs
+++ b/src/Ursa/Controls/Dialog/DialogWindow.cs
@@ -29,6 +29,27 @@ public class DialogWindow : Window
         set => SetValue(IsManagedResizerVisibleProperty, value);
     }
 
+    public static readonly StyledProperty<Thickness> ContentMarginProperty =
+        AvaloniaProperty.Register<DialogWindow, Thickness>(
+            nameof(ContentMargin),
+            new Thickness(0)
+        );
+    public Thickness ContentMargin
+    {
+        get => GetValue(ContentMarginProperty);
+        set => SetValue(ContentMarginProperty, value);
+    }
+    
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+        if (change.Property == TitleProperty)
+        {
+            ContentMargin = string.IsNullOrWhiteSpace(Title)
+                ?  new Thickness(0,0,0,0)
+                : new Thickness(0,48,0,0);
+        }
+    }
     static DialogWindow()
     {
         DataContextProperty.Changed.AddClassHandler<DialogWindow, object?>((window, e) =>

--- a/src/Ursa/Controls/Dialog/OverlayDialog.cs
+++ b/src/Ursa/Controls/Dialog/OverlayDialog.cs
@@ -218,6 +218,7 @@ public static class OverlayDialog
         control.IsCloseButtonVisible = options.IsCloseButtonVisible;
         control.CanLightDismiss = options.CanLightDismiss;
         control.CanResize = options.CanResize;
+        control.Title = options?.Title ?? string.Empty;
         if (!string.IsNullOrWhiteSpace(options.StyleClass))
         {
             var styles = options.StyleClass!.Split(Constants.SpaceSeparator, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
修复 Dialog.ShowCustomModal & Dialog.ShowCustom 有 Title选项时，标题内容区域重叠问题；OverlayDialog.ShowCustomModal 和 OverlayDialog.ShowCustom 增加 Title 选项。