### PR TITLE
修复PathPicker选中多个文件时SelectedPathsText第一行没有分行的bug

### DIFF
--- a/src/Ursa/Controls/PathPicker/PathPicker.cs
+++ b/src/Ursa/Controls/PathPicker/PathPicker.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
@@ -159,17 +158,8 @@ public partial class PathPicker : TemplatedControl
         if (change.Property == SelectedPathsProperty)
         {
             _twoConvertLock = true;
-            var stringBuilder = new StringBuilder();
-            if (SelectedPaths.Count != 0)
-            {
-                stringBuilder.Append(SelectedPaths[0]);
-                foreach (var item in SelectedPaths.Skip(1))
-                {
-                    stringBuilder.AppendLine(item);
-                }
-            }
 
-            SelectedPathsText = stringBuilder.ToString();
+            SelectedPathsText = string.Join(Environment.NewLine, SelectedPaths);
             _twoConvertLock = false;
         }
 


### PR DESCRIPTION
如图所示
![QQ截图20260106233830](https://github.com/user-attachments/assets/c55cf908-21d3-4cff-83a7-a8dc94b00785)
