### PR TITLE
Update TimePicker to correctly handle second selector panel type

### DIFF
--- a/src/Ursa.Themes.Semi/Controls/TimePicker.axaml
+++ b/src/Ursa.Themes.Semi/Controls/TimePicker.axaml
@@ -72,7 +72,7 @@
                             Name="{x:Static u:TimePickerPresenter.PART_SecondSelector}"
                             MinWidth="64"
                             ItemHeight="32"
-                            PanelType="Minute"
+                            PanelType="Second"
                             ShouldLoop="True" />
                     </ScrollViewer>
                     <Rectangle

--- a/src/Ursa/Controls/DateTimePicker/TimePickerPresenter.cs
+++ b/src/Ursa/Controls/DateTimePicker/TimePickerPresenter.cs
@@ -148,7 +148,7 @@ public class TimePickerPresenter : TemplatedControl
                 else if (part[0] == 's' && !panels.Contains(_secondScrollPanel))
                 {
                     panels.Add(_secondScrollPanel);
-                    _secondSelector?.SetValue(DateTimePickerPanel.ItemFormatProperty, part.Replace('s', 'm'));
+                    _secondSelector?.SetValue(DateTimePickerPanel.ItemFormatProperty, part);
                 }
                 else if (part[0] == 't' && !panels.Contains(_ampmScrollPanel))
                 {


### PR DESCRIPTION
Since we no longer maintain backward compatibility with Avalonia 11.1, so we can just remove the hack of `second` panel handling. 