### PR TITLE
feat(ElasticWrapPanel): 添加 KeepAspectRatio 属性以在填充时保持长宽比

### DIFF
--- a/demo/Ursa.Demo/Pages/ElasticWrapPanelDemo.axaml
+++ b/demo/Ursa.Demo/Pages/ElasticWrapPanelDemo.axaml
@@ -80,6 +80,11 @@
                         Minimum="-10"
                         Value="{Binding LineSpacing}" />
                 </u:FormItem>
+                <u:FormItem>
+                    <u:FormItem.Label>
+                        <CheckBox Content="KeepAspectRatio" IsChecked="{Binding KeepAspectRatio}" />
+                    </u:FormItem.Label>
+                </u:FormItem>
             </u:FormGroup>
             <u:FormGroup Header="FixToRB Extension" IsEnabled="{Binding #FixToRBTabItem.IsSelected}">
                 <u:FormItem>
@@ -126,7 +131,8 @@
                                             ItemWidth="{Binding ItemWidth}"
                                             ItemSpacing="{Binding ItemSpacing}"
                                             LineSpacing="{Binding LineSpacing}"
-                                            Orientation="{Binding SelectedOrientation}">
+                                            Orientation="{Binding SelectedOrientation}"
+                                            KeepAspectRatio="{Binding KeepAspectRatio}">
                             <Border Background="{DynamicResource SemiRed5Color}" />
                             <Border Background="{DynamicResource SemiPink5Color}" />
                             <Border Background="{DynamicResource SemiPurple5Color}" />
@@ -150,6 +156,7 @@
                             <u:ElasticWrapPanel Grid.Row="0"
                                                 IsFillHorizontal="{Binding IsFillHorizontal}"
                                                 IsFillVertical="{Binding IsFillVertical}"
+                                                KeepAspectRatio="{Binding KeepAspectRatio}"
                                                 ItemHeight="{Binding ItemHeight}"
                                                 ItemWidth="{Binding ItemWidth}"
                                                 ItemSpacing="{Binding ItemSpacing}"
@@ -183,6 +190,7 @@
                                           VerticalScrollBarVisibility="{Binding VerticalVisibility}">
                                 <u:ElasticWrapPanel IsFillHorizontal="{Binding IsFillHorizontal}"
                                                     IsFillVertical="{Binding IsFillVertical}"
+                                                    KeepAspectRatio="{Binding KeepAspectRatio}"
                                                     ItemHeight="{Binding ItemHeight}"
                                                     ItemWidth="{Binding ItemWidth}"
                                                     ItemSpacing="{Binding ItemSpacing}"
@@ -245,6 +253,7 @@
                                         <u:Divider HorizontalContentAlignment="Left" Content="ElasticWrapPanel" />
                                         <u:ElasticWrapPanel IsFillHorizontal="{Binding IsFillHorizontal}"
                                                             IsFillVertical="{Binding IsFillVertical}"
+                                                            KeepAspectRatio="{Binding KeepAspectRatio}"
                                                             ItemHeight="{Binding ItemHeight}"
                                                             ItemWidth="{Binding ItemWidth}"
                                                             ItemSpacing="{Binding ItemSpacing}"
@@ -311,6 +320,7 @@
                                         <u:Divider HorizontalContentAlignment="Left" Content="ElasticWrapPanel" />
                                         <u:ElasticWrapPanel IsFillHorizontal="{Binding IsFillHorizontal}"
                                                             IsFillVertical="{Binding IsFillVertical}"
+                                                            KeepAspectRatio="{Binding KeepAspectRatio}"
                                                             ItemHeight="{Binding ItemHeight}"
                                                             ItemWidth="{Binding ItemWidth}"
                                                             ItemSpacing="{Binding ItemSpacing}"

--- a/demo/Ursa.Demo/ViewModels/ElasticWrapPanelDemoViewModel.cs
+++ b/demo/Ursa.Demo/ViewModels/ElasticWrapPanelDemoViewModel.cs
@@ -12,6 +12,7 @@ public partial class ElasticWrapPanelDemoViewModel : ObservableObject
 
     [ObservableProperty] private bool _isFillHorizontal;
     [ObservableProperty] private bool _isFillVertical;
+    [ObservableProperty] private bool _keepAspectRatio;
     [ObservableProperty] private double _itemWidth = 40d;
     [ObservableProperty] private double _itemHeight = 40d;
     [ObservableProperty] private double _itemSpacing;

--- a/src/Ursa/Controls/Panels/ElasticWrapPanel.cs
+++ b/src/Ursa/Controls/Panels/ElasticWrapPanel.cs
@@ -13,7 +13,7 @@ public class ElasticWrapPanel : WrapPanel
     static ElasticWrapPanel()
     {
         AffectsMeasure<ElasticWrapPanel>(IsFillHorizontalProperty, IsFillVerticalProperty, ItemSpacingProperty, LineSpacingProperty);
-        AffectsArrange<ElasticWrapPanel>(IsFillHorizontalProperty, IsFillVerticalProperty, ItemSpacingProperty, LineSpacingProperty);
+        AffectsArrange<ElasticWrapPanel>(IsFillHorizontalProperty, IsFillVerticalProperty, ItemSpacingProperty, LineSpacingProperty, KeepAspectRatioProperty);
     }
 
     #region AttachedProperty
@@ -58,6 +58,15 @@ public class ElasticWrapPanel : WrapPanel
 
     public static readonly StyledProperty<bool> IsFillVerticalProperty =
         AvaloniaProperty.Register<ElasticWrapPanel, bool>(nameof(IsFillVertical));
+
+    public bool KeepAspectRatio
+    {
+        get => GetValue(KeepAspectRatioProperty);
+        set => SetValue(KeepAspectRatioProperty, value);
+    }
+
+    public static readonly StyledProperty<bool> KeepAspectRatioProperty =
+        AvaloniaProperty.Register<ElasticWrapPanel, bool>(nameof(KeepAspectRatio));
 
     private int _lineCount;
 
@@ -394,6 +403,7 @@ public class ElasticWrapPanel : WrapPanel
                 }
             }
 
+            bool keepAspectRatio = KeepAspectRatio;
             bool isHorizontal = Orientation == Orientation.Horizontal;
             int lineIndex = 0;
             foreach (var uvCollection in lineUVCollection)
@@ -401,6 +411,7 @@ public class ElasticWrapPanel : WrapPanel
                 double u = 0;
                 var lineUIEles = uvCollection.UICollection.Keys.ToList();
                 double linevV = isAdaptV ? adaptVLength : uvCollection.LineV;
+                double maxScaledV = 0;
                 int itemIndex = 0;
                 foreach (var child in lineUIEles)
                 {
@@ -408,7 +419,23 @@ public class ElasticWrapPanel : WrapPanel
 
                     double layoutSlotU = childSize.UVSize.U + childSize.ULengthCount * adaptULength;
                     double layoutSlotV = isAdaptV ? linevV : childSize.UVSize.V;
-                    if (ElasticWrapPanel.GetIsFixToRB(child) == false)
+
+                    bool isFixToRB = GetIsFixToRB(child);
+                    if (isFixToRB && itemSetSize.U > 0)
+                    {
+                        layoutSlotU = childSize.ULengthCount * itemSetSize.U +
+                                      childSize.ULengthCount * adaptULength;
+                        double leaveULength = uvFinalSize.U - u;
+                        layoutSlotU = Min(leaveULength, layoutSlotU);
+                    }
+
+                    if (keepAspectRatio && isFillU && childSize.UVSize.U > 0 && childSize.UVSize.V > 0)
+                    {
+                        double scaleU = layoutSlotU / childSize.UVSize.U;
+                        layoutSlotV = childSize.UVSize.V * scaleU;
+                    }
+
+                    if (!isFixToRB)
                     {
                         child.Arrange(new Rect(
                             isHorizontal ? u : accumulatedV,
@@ -418,14 +445,6 @@ public class ElasticWrapPanel : WrapPanel
                     }
                     else
                     {
-                        if (itemSetSize.U > 0)
-                        {
-                            layoutSlotU = childSize.ULengthCount * itemSetSize.U +
-                                          childSize.ULengthCount * adaptULength;
-                            double leaveULength = uvFinalSize.U - u;
-                            layoutSlotU = Min(leaveULength, layoutSlotU);
-                        }
-
                         child.Arrange(new Rect(
                             isHorizontal ? Max(0, uvFinalSize.U - layoutSlotU) : accumulatedV,
                             isHorizontal ? accumulatedV : Max(0, uvFinalSize.U - layoutSlotU),
@@ -433,6 +452,7 @@ public class ElasticWrapPanel : WrapPanel
                             isHorizontal ? layoutSlotV : layoutSlotU));
                     }
 
+                    maxScaledV = Max(maxScaledV, layoutSlotV);
                     u += layoutSlotU;
                     if (itemIndex < lineUIEles.Count - 1)
                     {
@@ -441,7 +461,7 @@ public class ElasticWrapPanel : WrapPanel
                     itemIndex++;
                 }
 
-                accumulatedV += linevV;
+                accumulatedV += (keepAspectRatio && isFillU) ? maxScaledV : linevV;
                 if (lineIndex < lineUVCollection.Count - 1)
                 {
                     accumulatedV += lineSpacing;


### PR DESCRIPTION
## 功能说明
为 `ElasticWrapPanel` 添加 `KeepAspectRatio` 属性，在填充模式下保持子项的长宽比。

- **横排 + `IsFillHorizontal`**：水平拉伸宽度，高度按同比例缩放
- **竖排 + `IsFillVertical`**：垂直拉伸高度，宽度按同比例缩放

## 测试计划
- [ ] 横排模式下开启 `IsFillHorizontal` + `KeepAspectRatio`，验证子项保持长宽比
- [ ] 竖排模式下开启 `IsFillVertical` + `KeepAspectRatio`，验证子项保持长宽比
- [ ] 同时开启 `IsFillHorizontal` 和 `IsFillVertical` 时验证行为
- [ ] `KeepAspectRatio="False"`（默认值）保持原有行为
- [ ] `FixToRB` 子项与 `KeepAspectRatio` 配合正常
