### PR TITLE
feat: Add DefaultDateKind property for DatePicker components

### DIFF
--- a/src/Ursa/Controls/DateTimePicker/DatePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePicker.cs
@@ -123,7 +123,7 @@ public class DatePicker : DatePickerBase, IClearControl
 
     private void OnDateSelected(object? sender, DatePickerCalendarDayButtonEventArgs e)
     {
-        SetCurrentValue(SelectedDateProperty, e.Date);
+        SetCurrentValue(SelectedDateProperty, ApplyDateKind(e.Date));
         SetCurrentValue(IsDropdownOpenProperty, false);
     }
     
@@ -222,7 +222,7 @@ public class DatePicker : DatePickerBase, IClearControl
         if (DateTime.TryParseExact(_textBox?.Text, format, CultureInfo.CurrentUICulture, DateTimeStyles.None,
                 out var date))
         {
-            SetCurrentValue(SelectedDateProperty, date);
+            SetCurrentValue(SelectedDateProperty, ApplyDateKind(date));
             if (_calendar is not null)
             {
                 _calendar.ContextDate = _calendar.ContextDate.With(year: date.Year, month: date.Month);

--- a/src/Ursa/Controls/DateTimePicker/DatePickerBase.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePickerBase.cs
@@ -50,6 +50,9 @@ public class DatePickerBase : TemplatedControl, IInnerContentControl, IPopupInne
     public static readonly StyledProperty<bool> IsReadonlyProperty = AvaloniaProperty.Register<DatePickerBase, bool>(
         nameof(IsReadonly));
 
+    public static readonly StyledProperty<DateTimeKind> DefaultDateKindProperty =
+        AvaloniaProperty.Register<DatePickerBase, DateTimeKind>(nameof(DefaultDateKind), DateTimeKind.Unspecified);
+
     public AvaloniaList<DateRange> BlackoutDates
     {
         get => GetValue(BlackoutDatesProperty);
@@ -78,6 +81,18 @@ public class DatePickerBase : TemplatedControl, IInnerContentControl, IPopupInne
     {
         get => GetValue(IsReadonlyProperty);
         set => SetValue(IsReadonlyProperty, value);
+    }
+
+    public DateTimeKind DefaultDateKind
+    {
+        get => GetValue(DefaultDateKindProperty);
+        set => SetValue(DefaultDateKindProperty, value);
+    }
+
+    protected DateTime? ApplyDateKind(DateTime? date)
+    {
+        if (date is null) return null;
+        return DateTime.SpecifyKind(date.Value, DefaultDateKind);
     }
 
     public bool IsDropdownOpen

--- a/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
@@ -150,7 +150,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
         if (_status is { Current: Status.Start, Previous: Status.None })
         {
             // User make first selection: Start.
-            SetCurrentValue(SelectedStartDateProperty, e.Date);
+            SetCurrentValue(SelectedStartDateProperty, ApplyDateKind(e.Date));
             if (SelectedEndDate != null && e.Date > SelectedEndDate)
             {
                 SetCurrentValue(SelectedEndDateProperty, null);
@@ -161,15 +161,15 @@ public class DateRangePicker : DatePickerBase, IClearControl
         }
         else if (_status is { Current: Status.Start, Previous: Status.End })
         {
-            // User make second selection: Start. 
-            SetCurrentValue(SelectedStartDateProperty, e.Date);
+            // User make second selection: Start.
+            SetCurrentValue(SelectedStartDateProperty, ApplyDateKind(e.Date));
             _status.Reset();
             SetCurrentValue(IsDropdownOpenProperty, false);
         }
         else if (_status is { Current: Status.End, Previous: Status.None })
         {
             // User make first selection: End.
-            SetCurrentValue(SelectedEndDateProperty, e.Date);
+            SetCurrentValue(SelectedEndDateProperty, ApplyDateKind(e.Date));
             if (SelectedStartDate != null && e.Date < SelectedStartDate)
             {
                 SetCurrentValue(SelectedStartDateProperty, null);
@@ -181,7 +181,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
         else if (_status is { Current: Status.End, Previous: Status.Start })
         {
             // User make second selection: End.
-            SetCurrentValue(SelectedEndDateProperty, e.Date);
+            SetCurrentValue(SelectedEndDateProperty, ApplyDateKind(e.Date));
             _status.Reset();
             SetCurrentValue(IsDropdownOpenProperty, false);
         }
@@ -260,7 +260,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
                      out var start))
         {
             startDate = start;
-            SetCurrentValue(SelectedStartDateProperty, startDate);
+            SetCurrentValue(SelectedStartDateProperty, ApplyDateKind(startDate));
         }
         else
         {
@@ -278,7 +278,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
                      out var end))
         {
             endDate = end;
-            SetCurrentValue(SelectedEndDateProperty, endDate);
+            SetCurrentValue(SelectedEndDateProperty, ApplyDateKind(endDate));
         }
         else
         {

--- a/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
@@ -169,7 +169,7 @@ public class DateTimePicker : DatePickerBase, IClearControl
         if (DateTime.TryParseExact(_textBox?.Text, format, CultureInfo.CurrentUICulture, DateTimeStyles.None,
                 out var date))
         {
-            SetCurrentValue(SelectedDateProperty, date);
+            SetCurrentValue(SelectedDateProperty, ApplyDateKind(date));
         }
         else
         {
@@ -185,7 +185,7 @@ public class DateTimePicker : DatePickerBase, IClearControl
             var date = e.Date.Value;
             var time = DateTime.Now.TimeOfDay;
             SetCurrentValue(SelectedDateProperty,
-                new DateTime(date.Year, date.Month, date.Day, time.Hours, time.Minutes, time.Seconds));
+                ApplyDateKind(new DateTime(date.Year, date.Month, date.Day, time.Hours, time.Minutes, time.Seconds)));
         }
         else
         {
@@ -193,8 +193,8 @@ public class DateTimePicker : DatePickerBase, IClearControl
             if (e.Date is null) return;
             var date = e.Date.Value;
             SetCurrentValue(SelectedDateProperty,
-                new DateTime(date.Year, date.Month, date.Day, selectedDate.Value.Hour, selectedDate.Value.Minute,
-                    selectedDate.Value.Second));
+                ApplyDateKind(new DateTime(date.Year, date.Month, date.Day, selectedDate.Value.Hour, selectedDate.Value.Minute,
+                    selectedDate.Value.Second)));
         }
     }
 
@@ -206,7 +206,7 @@ public class DateTimePicker : DatePickerBase, IClearControl
             var time = e.NewTime.Value;
             var date = DateTime.Today;
             SetCurrentValue(SelectedDateProperty,
-                new DateTime(date.Year, date.Month, date.Day, time.Hours, time.Minutes, time.Seconds));
+                ApplyDateKind(new DateTime(date.Year, date.Month, date.Day, time.Hours, time.Minutes, time.Seconds)));
         }
         else
         {
@@ -214,9 +214,9 @@ public class DateTimePicker : DatePickerBase, IClearControl
             if (e.NewTime is null) return;
             var time = e.NewTime.Value;
             SetCurrentValue(SelectedDateProperty,
-                new DateTime(selectedDate.Value.Year, selectedDate.Value.Month, selectedDate.Value.Day, time.Hours,
+                ApplyDateKind(new DateTime(selectedDate.Value.Year, selectedDate.Value.Month, selectedDate.Value.Day, time.Hours,
                     time.Minutes,
-                    time.Seconds));
+                    time.Seconds)));
         }
     }
 

--- a/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
@@ -158,6 +158,23 @@ public class DateTimePicker : DatePickerBase, IClearControl
         InitializePopupOpen();
     }
 
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+        switch (e.Key)
+        {
+            case Key.Enter:
+                CommitInput();
+                SetCurrentValue(IsDropdownOpenProperty, false);
+                e.Handled = true;
+                break;
+            case Key.Down when e.KeyModifiers.HasFlag(KeyModifiers.Alt):
+                InitializePopupOpen();
+                e.Handled = true;
+                break;
+        }
+    }
+
     private void CommitInput()
     {
         var format = this.DisplayFormat ?? DEFAULT_DATETIME_DISPLAY_FORMAT;

--- a/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/CalendarViewHelper.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/CalendarViewHelper.cs
@@ -3,7 +3,7 @@ using Avalonia.Controls.Templates;
 using Avalonia.Interactivity;
 using Ursa.Controls;
 
-namespace HeadlessTest.Ursa.Controls.DateTimePicker;
+namespace HeadlessTest.Ursa.Controls.DateAndTimePickerTests;
 
 internal static class CalendarViewHelper
 {

--- a/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DatePickerCalendarDayButtonTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DatePickerCalendarDayButtonTests.cs
@@ -6,7 +6,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using Ursa.Controls;
 
-namespace HeadlessTest.Ursa.Controls.DateTimePicker;
+namespace HeadlessTest.Ursa.Controls.DateAndTimePickerTests;
 
 public class DatePickerCalendarDayButtonTests
 {

--- a/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DatePickerCalendarViewTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DatePickerCalendarViewTests.cs
@@ -9,7 +9,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Ursa.Controls;
 
-namespace HeadlessTest.Ursa.Controls.DateTimePicker;
+namespace HeadlessTest.Ursa.Controls.DateAndTimePickerTests;
 
 public class DatePickerCalendarViewTests
 {

--- a/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DatePickerCalendarYearButtonTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DatePickerCalendarYearButtonTests.cs
@@ -6,7 +6,7 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Ursa.Controls;
 
-namespace HeadlessTest.Ursa.Controls.DateTimePicker;
+namespace HeadlessTest.Ursa.Controls.DateAndTimePickerTests;
 
 public class DatePickerCalendarYearButtonTests
 {

--- a/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DatePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DatePickerTests.cs
@@ -11,7 +11,7 @@ using HeadlessTest.Ursa.TestHelpers;
 using Ursa.Controls;
 using DatePicker = Ursa.Controls.DatePicker;
 
-namespace HeadlessTest.Ursa.Controls.DateTimePicker;
+namespace HeadlessTest.Ursa.Controls.DateAndTimePickerTests;
 
 public class DatePickerTests
 {
@@ -258,6 +258,109 @@ public class DatePickerTests
         window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
         Dispatcher.UIThread.RunJobs();
         Assert.Equal(new DateTime(2025, 2, 18), picker.SelectedDate);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Utc_Applied_When_Calendar_Date_Selected()
+    {
+        var window = new Window();
+        var picker = new DatePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd",
+            DefaultDateKind = DateTimeKind.Utc,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        var popup = picker.GetTemplateChildOfType<Popup>(DatePicker.PART_Popup);
+        var calendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
+        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateTime(2025, 2, 17))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedDate!.Value.Kind);
+        Assert.Equal(new DateTime(2025, 2, 17, 0, 0, 0, DateTimeKind.Utc), picker.SelectedDate!.Value);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Local_Applied_When_Calendar_Date_Selected()
+    {
+        var window = new Window();
+        var picker = new DatePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd",
+            DefaultDateKind = DateTimeKind.Local,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        var popup = picker.GetTemplateChildOfType<Popup>(DatePicker.PART_Popup);
+        var calendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
+        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateTime(2025, 3, 10))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Local, picker.SelectedDate!.Value.Kind);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Utc_Applied_When_Text_Parsed()
+    {
+        var window = new Window();
+        var picker = new DatePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd",
+            DefaultDateKind = DateTimeKind.Utc,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var textBox = picker.GetTemplateChildOfType<TextBox>(DatePicker.PART_TextBox);
+        textBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        textBox?.SetValue(TextBox.TextProperty, "2025-06-15");
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedDate!.Value.Kind);
+        Assert.Equal(new DateTime(2025, 6, 15, 0, 0, 0, DateTimeKind.Utc), picker.SelectedDate!.Value);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Unspecified_Is_Default()
+    {
+        var window = new Window();
+        var picker = new DatePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd",
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var textBox = picker.GetTemplateChildOfType<TextBox>(DatePicker.PART_TextBox);
+        textBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        textBox?.SetValue(TextBox.TextProperty, "2025-06-15");
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Unspecified, picker.SelectedDate!.Value.Kind);
     }
     /*
     [AvaloniaFact]

--- a/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DateRangePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DateRangePickerTests.cs
@@ -1,0 +1,170 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using HeadlessTest.Ursa.TestHelpers;
+using Ursa.Controls;
+
+namespace HeadlessTest.Ursa.Controls.DateAndTimePickerTests;
+
+public class DateRangePickerTests
+{
+    [AvaloniaFact]
+    public void DefaultDateKind_Utc_Applied_When_Start_Date_Selected_From_Calendar()
+    {
+        var window = new Window();
+        var picker = new DateRangePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd",
+            DefaultDateKind = DateTimeKind.Utc,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePicker.PART_StartTextBox);
+        startTextBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        var popup = picker.GetTemplateChildOfType<Popup>(DateRangePicker.PART_Popup);
+        var startCalendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
+        startCalendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateTime(2025, 3, 10))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedStartDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedStartDate!.Value.Kind);
+        Assert.Equal(new DateTime(2025, 3, 10, 0, 0, 0, DateTimeKind.Utc), picker.SelectedStartDate!.Value);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Utc_Applied_When_End_Date_Selected_From_Calendar()
+    {
+        var window = new Window();
+        var picker = new DateRangePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd",
+            DefaultDateKind = DateTimeKind.Utc,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        // Focus start box first to set Status to Start
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePicker.PART_StartTextBox);
+        startTextBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        var popup = picker.GetTemplateChildOfType<Popup>(DateRangePicker.PART_Popup);
+        var startCalendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
+        // Select start date first
+        startCalendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateTime(2025, 3, 10))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+        // Now focus end box and select end date
+        var endTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePicker.PART_EndTextBox);
+        endTextBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        var calendars = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().ToList();
+        var endCalendar = calendars?.ElementAtOrDefault(1) ?? calendars?.FirstOrDefault();
+        endCalendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateTime(2025, 3, 20))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedEndDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedEndDate!.Value.Kind);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Utc_Applied_When_Start_Text_Parsed()
+    {
+        var window = new Window();
+        var picker = new DateRangePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd",
+            DefaultDateKind = DateTimeKind.Utc,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        var button = new Button() { Width = 100 };
+        window.Content = new StackPanel()
+        {
+            Children = { picker, button }
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePicker.PART_StartTextBox);
+        startTextBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        startTextBox?.SetValue(TextBox.TextProperty, "2025-04-01");
+        button.Focus();
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedStartDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedStartDate!.Value.Kind);
+        Assert.Equal(new DateTime(2025, 4, 1, 0, 0, 0, DateTimeKind.Utc), picker.SelectedStartDate!.Value);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Utc_Applied_When_End_Text_Parsed()
+    {
+        var window = new Window();
+        var picker = new DateRangePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd",
+            DefaultDateKind = DateTimeKind.Utc,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        var button = new Button() { Width = 100 };
+        window.Content = new StackPanel()
+        {
+            Children = { picker, button }
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var endTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePicker.PART_EndTextBox);
+        endTextBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        endTextBox?.SetValue(TextBox.TextProperty, "2025-04-30");
+        button.Focus();
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedEndDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedEndDate!.Value.Kind);
+        Assert.Equal(new DateTime(2025, 4, 30, 0, 0, 0, DateTimeKind.Utc), picker.SelectedEndDate!.Value);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Unspecified_Is_Default()
+    {
+        var window = new Window();
+        var picker = new DateRangePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd",
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        var button = new Button() { Width = 100 };
+        window.Content = new StackPanel()
+        {
+            Children = { picker, button }
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePicker.PART_StartTextBox);
+        startTextBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        startTextBox?.SetValue(TextBox.TextProperty, "2025-04-01");
+        button.Focus();
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedStartDate);
+        Assert.Equal(DateTimeKind.Unspecified, picker.SelectedStartDate!.Value.Kind);
+    }
+}

--- a/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DateTimePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/DateTimePickerTests.cs
@@ -1,0 +1,156 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using HeadlessTest.Ursa.TestHelpers;
+using Irihi.Avalonia.Shared.Common;
+using Ursa.Controls;
+using TimePickerPresenter = Ursa.Controls.TimePickerPresenter;
+
+namespace HeadlessTest.Ursa.Controls.DateAndTimePickerTests;
+
+public class DateTimePickerTests
+{
+    [AvaloniaFact]
+    public void DefaultDateKind_Utc_Applied_When_Calendar_Date_Selected()
+    {
+        var window = new Window();
+        var picker = new DateTimePicker()
+        {
+            Width = 300,
+            DefaultDateKind = DateTimeKind.Utc,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        var popup = picker.GetTemplateChildOfType<Popup>(PartNames.PART_Popup);
+        var calendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
+        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateTime(2025, 2, 17))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedDate!.Value.Kind);
+        Assert.Equal(2025, picker.SelectedDate!.Value.Year);
+        Assert.Equal(2, picker.SelectedDate!.Value.Month);
+        Assert.Equal(17, picker.SelectedDate!.Value.Day);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Local_Applied_When_Calendar_Date_Selected()
+    {
+        var window = new Window();
+        var picker = new DateTimePicker()
+        {
+            Width = 300,
+            DefaultDateKind = DateTimeKind.Local,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        var popup = picker.GetTemplateChildOfType<Popup>(DateTimePicker.PART_Popup);
+        var calendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
+        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateTime(2025, 5, 20))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Local, picker.SelectedDate!.Value.Kind);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Utc_Applied_When_Text_Parsed()
+    {
+        var window = new Window();
+        var picker = new DateTimePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd HH:mm:ss",
+            DefaultDateKind = DateTimeKind.Utc,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var textBox = picker.GetTemplateChildOfType<TextBox>(DateTimePicker.PART_TextBox);
+        textBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        textBox?.SetValue(TextBox.TextProperty, "2025-06-15 10:30:00");
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedDate!.Value.Kind);
+        Assert.Equal(new DateTime(2025, 6, 15, 10, 30, 0, DateTimeKind.Utc), picker.SelectedDate!.Value);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Unspecified_Is_Default()
+    {
+        var window = new Window();
+        var picker = new DateTimePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd HH:mm:ss",
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var textBox = picker.GetTemplateChildOfType<TextBox>(DateTimePicker.PART_TextBox);
+        textBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        textBox?.SetValue(TextBox.TextProperty, "2025-06-15 10:30:00");
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Unspecified, picker.SelectedDate!.Value.Kind);
+    }
+
+    [AvaloniaFact]
+    public void DefaultDateKind_Preserved_When_Time_Changes()
+    {
+        var window = new Window();
+        var picker = new DateTimePicker()
+        {
+            Width = 300,
+            DisplayFormat = "yyyy-MM-dd HH:mm:ss",
+            DefaultDateKind = DateTimeKind.Utc,
+            HorizontalAlignment = HorizontalAlignment.Left,
+            VerticalAlignment = VerticalAlignment.Top
+        };
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+        var textBox = picker.GetTemplateChildOfType<TextBox>(DateTimePicker.PART_TextBox);
+        textBox?.Focus();
+        Dispatcher.UIThread.RunJobs();
+        textBox?.SetValue(TextBox.TextProperty, "2025-06-15 10:30:00");
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedDate!.Value.Kind);
+
+        // Simulate time change via TimePickerPresenter event
+        var popup = picker.GetTemplateChildOfType<Popup>(DateTimePicker.PART_Popup);
+        var timePicker = popup?.GetLogicalDescendants().OfType<TimePickerPresenter>().FirstOrDefault();
+        timePicker?.RaiseEvent(new TimeChangedEventArgs(new TimeSpan(10, 30, 0), new TimeSpan(14, 0, 0))
+            { RoutedEvent = TimePickerPresenter.SelectedTimeChangedEvent });
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+        Assert.Equal(DateTimeKind.Utc, picker.SelectedDate!.Value.Kind);
+        Assert.Equal(14, picker.SelectedDate!.Value.Hour);
+    }
+}

--- a/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/TimePickerPresenterTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/TimePickerPresenterTests.cs
@@ -5,7 +5,7 @@ using Avalonia.Headless.XUnit;
 using Avalonia.Threading;
 using TimePickerPresenter = Ursa.Controls.TimePickerPresenter;
 
-namespace HeadlessTest.Ursa.Controls.DateTimePicker;
+namespace HeadlessTest.Ursa.Controls.DateAndTimePickerTests;
 
 public class TimePickerPresenterTests
 {

--- a/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/TimePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateAndTimePickerTests/TimePickerTests.cs
@@ -8,7 +8,7 @@ using Avalonia.Threading;
 using HeadlessTest.Ursa.TestHelpers;
 using TimePicker = Ursa.Controls.TimePicker;
 
-namespace HeadlessTest.Ursa.Controls.DateTimePicker;
+namespace HeadlessTest.Ursa.Controls.DateAndTimePickerTests;
 
 public class TimePickerTests
 {

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePicker/DatePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePicker/DatePickerTests.cs
@@ -235,7 +235,7 @@ public class DatePickerTests
         Assert.Equal("2025-02-18", textBox?.Text);
     }
     
-    /*
+    
     [AvaloniaFact]
     public void Set_Valid_TextBox_Text_Updates_SelectedDate()
     {
@@ -251,14 +251,15 @@ public class DatePickerTests
         window.Show();
         Dispatcher.UIThread.RunJobs();
         var textBox = picker.GetTemplateChildOfType<TextBox>(DatePicker.PART_TextBox);
-        textBox?.RaiseEvent(new TextChangedEventArgs(TextBox.TextChangedEvent));
+        textBox?.Focus();
         Dispatcher.UIThread.RunJobs();
         Assert.Null(picker.SelectedDate);
         textBox?.SetValue(TextBox.TextProperty, "2025-02-18");
+        window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
         Dispatcher.UIThread.RunJobs();
         Assert.Equal(new DateTime(2025, 2, 18), picker.SelectedDate);
     }
-    
+    /*
     [AvaloniaFact]
     public void Set_Invalid_TextBox_Text_Clears_SelectedDate()
     {


### PR DESCRIPTION
## Summary

- Add `DefaultDateKind` property to `DatePicker`, `DateRangePicker`, and `DateTimePicker` to control whether selected dates are treated as `Local` or `Utc`
- Apply the configured date kind when converting selected dates, ensuring consistent `DateTimeKind` on output values
- Refactor DateTimePicker headless tests into `DateAndTimePickerTests` folder with improved organization
- Add new `DefaultDateKind`-specific tests for `DatePickerTests`, `DateRangePickerTests`, and `DateTimePickerTests`

## Test plan

- [x] Verify `DefaultDateKind = Local` produces `DateTimeKind.Local` on selected date output
- [x] Verify `DefaultDateKind = Utc` produces `DateTimeKind.Utc` on selected date output
- [x] Run headless tests: `DatePickerTests`, `DateRangePickerTests`, `DateTimePickerTests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)