### PR TITLE
feat: use DateOnly and TimeOnly as payload of DatePickerCalendarView …

### DIFF
--- a/src/Ursa/Controls/DateTimePicker/DatePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePicker.cs
@@ -101,7 +101,8 @@ public class DatePicker : DatePickerBase, IClearControl
     {
         SetCurrentValue(IsDropdownOpenProperty, true);
         SetCalendarContextDate();
-        _calendar?.MarkDates(SelectedDate?.Date, SelectedDate?.Date);
+        var selectedDate = SelectedDate.ToDateOnly();
+        _calendar?.MarkDates(selectedDate, selectedDate);
     }
 
     private void OnTextBoxLostFocus(object? sender, FocusChangedEventArgs e)
@@ -123,7 +124,7 @@ public class DatePicker : DatePickerBase, IClearControl
 
     private void OnDateSelected(object? sender, DatePickerCalendarDayButtonEventArgs e)
     {
-        SetCurrentValue(SelectedDateProperty, e.Date);
+        SetCurrentValue(SelectedDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
         SetCurrentValue(IsDropdownOpenProperty, false);
     }
     
@@ -137,7 +138,8 @@ public class DatePicker : DatePickerBase, IClearControl
         else
         {
             _textBox?.SetValue(TextBox.TextProperty, date.Value.ToString(DisplayFormat ?? "yyyy-MM-dd"));
-            _calendar?.MarkDates(startDate: date.Value, endDate: date.Value);
+            var selectedDate = date.ToDateOnly();
+            _calendar?.MarkDates(startDate: selectedDate, endDate: selectedDate);
         }
     }
 
@@ -229,7 +231,8 @@ public class DatePicker : DatePickerBase, IClearControl
                 _calendar.UpdateDayButtons();
             }
 
-            _calendar?.MarkDates(startDate: date, endDate: date);
+            var selectedDate = date.ToDateOnly();
+            _calendar?.MarkDates(startDate: selectedDate, endDate: selectedDate);
         }
         else
         {

--- a/src/Ursa/Controls/DateTimePicker/DatePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePicker.cs
@@ -124,7 +124,7 @@ public class DatePicker : DatePickerBase, IClearControl
 
     private void OnDateSelected(object? sender, DatePickerCalendarDayButtonEventArgs e)
     {
-        SetCurrentValue(SelectedDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
+        SetCurrentValue(SelectedDateProperty, e.Date?.ToDateTime(TimeOnly.MinValue));
         SetCurrentValue(IsDropdownOpenProperty, false);
     }
     

--- a/src/Ursa/Controls/DateTimePicker/DatePickerCalendarDayButton.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePickerCalendarDayButton.cs
@@ -171,14 +171,14 @@ public class DatePickerCalendarDayButton : ContentControl
     protected override void OnPointerReleased(PointerReleasedEventArgs e)
     {
         base.OnPointerReleased(e);
-        if (DataContext is DateTime d)
+        if (DataContext is DateOnly d)
             RaiseEvent(new DatePickerCalendarDayButtonEventArgs(d) { RoutedEvent = DateSelectedEvent, Source = this });
     }
 
     protected override void OnPointerEntered(PointerEventArgs e)
     {
         base.OnPointerEntered(e);
-        if (DataContext is DateTime d)
+        if (DataContext is DateOnly d)
             RaiseEvent(new DatePickerCalendarDayButtonEventArgs(d) { RoutedEvent = DatePreviewedEvent, Source = this });
     }
 

--- a/src/Ursa/Controls/DateTimePicker/DatePickerCalendarDayButtonEventArgs.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePickerCalendarDayButtonEventArgs.cs
@@ -2,7 +2,7 @@
 
 namespace Ursa.Controls;
 
-public class DatePickerCalendarDayButtonEventArgs(DateTime? date) : RoutedEventArgs
+public class DatePickerCalendarDayButtonEventArgs(DateOnly? date) : RoutedEventArgs
 {
-    public DateTime? Date { get; private set; } = date;
+    public DateOnly? Date { get; private set; } = date;
 }

--- a/src/Ursa/Controls/DateTimePicker/DatePickerCalendarView.cs
+++ b/src/Ursa/Controls/DateTimePicker/DatePickerCalendarView.cs
@@ -1,4 +1,3 @@
-﻿using System.Diagnostics;
 using System.Globalization;
 using Avalonia;
 using Avalonia.Controls;
@@ -8,7 +7,6 @@ using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Irihi.Avalonia.Shared.Helpers;
-using Calendar = System.Globalization.Calendar;
 
 namespace Ursa.Controls;
 
@@ -47,7 +45,6 @@ public class DatePickerCalendarView : TemplatedControl
     public static readonly StyledProperty<DayOfWeek> FirstDayOfWeekProperty =
         DatePickerBase.FirstDayOfWeekProperty.AddOwner<DatePickerCalendarView>();
 
-    private readonly Calendar _calendar = new GregorianCalendar();
     private Button? _fastNextButton;
 
     private Button? _fastPreviousButton;
@@ -62,10 +59,10 @@ public class DatePickerCalendarView : TemplatedControl
     private Button? _yearButton;
     private Grid? _yearGrid;
 
-    private DateTime? _start;
-    private DateTime? _end;
-    private DateTime? _previewStart;
-    private DateTime? _previewEnd;
+    private DateOnly? _start;
+    private DateOnly? _end;
+    private DateOnly? _previewStart;
+    private DateOnly? _previewEnd;
 
     static DatePickerCalendarView()
     {
@@ -174,7 +171,8 @@ public class DatePickerCalendarView : TemplatedControl
         Button.ClickEvent.AddHandler(OnNext, _nextButton);
         Button.ClickEvent.AddHandler(OnFastNext, _fastNextButton);
 
-        ContextDate = new DatePickerCalendarContext(DateTime.Today.Year, DateTime.Today.Month);
+        var today = DateTime.Today.ToDateOnly();
+        ContextDate = new DatePickerCalendarContext(today.Year, today.Month);
         PseudoClasses.Set(PC_Month, Mode == DatePickerCalendarViewMode.Month);
         InitializeGridButtons();
         UpdateDayButtons();
@@ -330,16 +328,17 @@ public class DatePickerCalendarView : TemplatedControl
         if (_monthGrid is null || Mode != DatePickerCalendarViewMode.Month) return;
         var children = _monthGrid.Children;
         var info = DateTimeHelper.GetCurrentDateTimeFormatInfo();
-        var date = new DateTime(ContextDate.Year ?? ContextDate.StartYear!.Value, ContextDate.Month!.Value, 1);
+        var date = new DateOnly(ContextDate.Year ?? ContextDate.StartYear!.Value, ContextDate.Month!.Value, 1);
         var dayBefore = PreviousMonthDays(date);
         var dateToSet = date.GetFirstDayOfMonth().AddDays(-dayBefore);
+        var today = DateTime.Today.ToDateOnly();
         for (var i = 7; i < children.Count; i++)
         {
             var day = dateToSet;
             var cell = children[i] as DatePickerCalendarDayButton;
             if (cell is null) continue;
             cell.DataContext = day;
-            if (IsTodayHighlighted) cell.IsToday = day == DateTime.Today;
+            if (IsTodayHighlighted) cell.IsToday = day == today;
             cell.Content = day.Day.ToString(info);
             dateToSet = dateToSet.AddDays(1);
         }
@@ -394,7 +393,7 @@ public class DatePickerCalendarView : TemplatedControl
         if (_monthGrid is null) return;
         var children = _monthGrid.Children;
         for (var i = 7; i < children.Count; i++)
-            if (children[i] is DatePickerCalendarDayButton { DataContext: DateTime d } button)
+            if (children[i] is DatePickerCalendarDayButton { DataContext: DateOnly d } button)
                 button.IsNotCurrentMonth = d.Month != ContextDate.Month;
     }
 
@@ -414,10 +413,10 @@ public class DatePickerCalendarView : TemplatedControl
             }
     }
 
-    private int PreviousMonthDays(DateTime date)
+    private int PreviousMonthDays(DateOnly date)
     {
         var firstDay = date.GetFirstDayOfMonth();
-        var dayOfWeek = _calendar.GetDayOfWeek(firstDay);
+        var dayOfWeek = firstDay.DayOfWeek;
         var firstDayOfWeek = FirstDayOfWeek;
         var i = (dayOfWeek - firstDayOfWeek + DateTimeHelper.NumberOfDaysPerWeek) % DateTimeHelper.NumberOfDaysPerWeek;
         return i == 0 ? DateTimeHelper.NumberOfDaysPerWeek : i;
@@ -544,22 +543,22 @@ public class DatePickerCalendarView : TemplatedControl
         IsEnabledProperty.SetValue(canNext, _nextButton, _fastNextButton);
     }
     
-    internal void MarkDates(DateTime? startDate = null, DateTime? endDate = null, DateTime? previewStartDate = null, DateTime? previewEndDate = null)
+    internal void MarkDates(DateOnly? startDate = null, DateOnly? endDate = null, DateOnly? previewStartDate = null, DateOnly? previewEndDate = null)
     {
         _start = startDate;
         _end = endDate;
         _previewStart = previewStartDate;
         _previewEnd = previewEndDate;
         if (_monthGrid?.Children is null) return;
-        DateTime start = startDate ?? DateTime.MaxValue;
-        DateTime end = endDate ?? DateTime.MinValue;
-        DateTime previewStart = previewStartDate ?? DateTime.MaxValue;
-        DateTime previewEnd = previewEndDate ?? DateTime.MinValue;
-        DateTime rangeStart = DateTimeHelper.Min(start, previewStart);
-        DateTime rangeEnd = DateTimeHelper.Max(end, previewEnd);
+        var start = startDate ?? DateOnly.MaxValue;
+        var end = endDate ?? DateOnly.MinValue;
+        var previewStart = previewStartDate ?? DateOnly.MaxValue;
+        var previewEnd = previewEndDate ?? DateOnly.MinValue;
+        var rangeStart = start < previewStart ? start : previewStart;
+        var rangeEnd = end > previewEnd ? end : previewEnd;
         foreach (var child in _monthGrid.Children)
         {
-            if (child is not DatePickerCalendarDayButton { DataContext: DateTime d } button) continue;
+            if (child is not DatePickerCalendarDayButton { DataContext: DateOnly d } button) continue;
             button.ResetSelection();
             if(d.Month != ContextDate.Month) continue;
             if (d < rangeEnd && d > rangeStart) button.IsInRange = true;

--- a/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
@@ -105,14 +105,14 @@ public class DateRangePicker : DatePickerBase, IClearControl
         if (_status.Current == Status.Start)
         {
             // This means user is previewing start date, so mark on start. 
-            _startCalendar?.MarkDates(SelectedStartDate, SelectedEndDate, e.Date);
-            _endCalendar?.MarkDates(SelectedStartDate, SelectedEndDate, e.Date);
+            _startCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly(), e.Date);
+            _endCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly(), e.Date);
         }
         else if (_status.Current == Status.End)
         {
             // This means user is previewing end date, so mark on end. 
-            _startCalendar?.MarkDates(SelectedStartDate, SelectedEndDate, null, e.Date);
-            _endCalendar?.MarkDates(SelectedStartDate, SelectedEndDate, null, e.Date);
+            _startCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly(), null, e.Date);
+            _endCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly(), null, e.Date);
         }
         else
         {
@@ -140,8 +140,8 @@ public class DateRangePicker : DatePickerBase, IClearControl
             _status.Push(Status.End);
         }
 
-        _startCalendar?.MarkDates(SelectedStartDate, SelectedEndDate);
-        _endCalendar?.MarkDates(SelectedStartDate, SelectedEndDate);
+        _startCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly());
+        _endCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly());
     }
 
 
@@ -150,8 +150,8 @@ public class DateRangePicker : DatePickerBase, IClearControl
         if (_status is { Current: Status.Start, Previous: Status.None })
         {
             // User make first selection: Start.
-            SetCurrentValue(SelectedStartDateProperty, e.Date);
-            if (SelectedEndDate != null && e.Date > SelectedEndDate)
+            SetCurrentValue(SelectedStartDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
+            if (SelectedEndDate.ToDateOnly() is { } selectedEndDate && e.Date is { } selectedDate && selectedDate > selectedEndDate)
             {
                 SetCurrentValue(SelectedEndDateProperty, null);
             }
@@ -162,15 +162,15 @@ public class DateRangePicker : DatePickerBase, IClearControl
         else if (_status is { Current: Status.Start, Previous: Status.End })
         {
             // User make second selection: Start. 
-            SetCurrentValue(SelectedStartDateProperty, e.Date);
+            SetCurrentValue(SelectedStartDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
             _status.Reset();
             SetCurrentValue(IsDropdownOpenProperty, false);
         }
         else if (_status is { Current: Status.End, Previous: Status.None })
         {
             // User make first selection: End.
-            SetCurrentValue(SelectedEndDateProperty, e.Date);
-            if (SelectedStartDate != null && e.Date < SelectedStartDate)
+            SetCurrentValue(SelectedEndDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
+            if (SelectedStartDate.ToDateOnly() is { } selectedStartDate && e.Date is { } selectedDate && selectedDate < selectedStartDate)
             {
                 SetCurrentValue(SelectedStartDateProperty, null);
             }
@@ -181,7 +181,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
         else if (_status is { Current: Status.End, Previous: Status.Start })
         {
             // User make second selection: End.
-            SetCurrentValue(SelectedEndDateProperty, e.Date);
+            SetCurrentValue(SelectedEndDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
             _status.Reset();
             SetCurrentValue(IsDropdownOpenProperty, false);
         }
@@ -213,8 +213,8 @@ public class DateRangePicker : DatePickerBase, IClearControl
     private void OnSelectionChanged()
     {
         SyncDatesToTexts();
-        _startCalendar?.MarkDates(SelectedStartDate, SelectedEndDate);
-        _endCalendar?.MarkDates(SelectedStartDate, SelectedEndDate);
+        _startCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly());
+        _endCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly());
         PseudoClasses.Set(PseudoClassName.PC_Empty, SelectedStartDate is null && SelectedEndDate is null);
     }
 
@@ -286,8 +286,8 @@ public class DateRangePicker : DatePickerBase, IClearControl
             SetCurrentValue(SelectedEndDateProperty, endDate);
         }
 
-        _startCalendar?.MarkDates(SelectedStartDate, SelectedEndDate);
-        _endCalendar?.MarkDates(SelectedStartDate, SelectedEndDate);
+        _startCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly());
+        _endCalendar?.MarkDates(SelectedStartDate.ToDateOnly(), SelectedEndDate.ToDateOnly());
     }
 
     protected override void OnPointerPressed(PointerPressedEventArgs e)

--- a/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateRangePicker.cs
@@ -150,7 +150,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
         if (_status is { Current: Status.Start, Previous: Status.None })
         {
             // User make first selection: Start.
-            SetCurrentValue(SelectedStartDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
+            SetCurrentValue(SelectedStartDateProperty, e.Date?.ToDateTime(TimeOnly.MinValue));
             if (SelectedEndDate.ToDateOnly() is { } selectedEndDate && e.Date is { } selectedDate && selectedDate > selectedEndDate)
             {
                 SetCurrentValue(SelectedEndDateProperty, null);
@@ -162,14 +162,14 @@ public class DateRangePicker : DatePickerBase, IClearControl
         else if (_status is { Current: Status.Start, Previous: Status.End })
         {
             // User make second selection: Start. 
-            SetCurrentValue(SelectedStartDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
+            SetCurrentValue(SelectedStartDateProperty, e.Date?.ToDateTime(TimeOnly.MinValue));
             _status.Reset();
             SetCurrentValue(IsDropdownOpenProperty, false);
         }
         else if (_status is { Current: Status.End, Previous: Status.None })
         {
             // User make first selection: End.
-            SetCurrentValue(SelectedEndDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
+            SetCurrentValue(SelectedEndDateProperty, e.Date?.ToDateTime(TimeOnly.MinValue));
             if (SelectedStartDate.ToDateOnly() is { } selectedStartDate && e.Date is { } selectedDate && selectedDate < selectedStartDate)
             {
                 SetCurrentValue(SelectedStartDateProperty, null);
@@ -181,7 +181,7 @@ public class DateRangePicker : DatePickerBase, IClearControl
         else if (_status is { Current: Status.End, Previous: Status.Start })
         {
             // User make second selection: End.
-            SetCurrentValue(SelectedEndDateProperty, e.Date.ToDateTime(TimeOnly.MinValue));
+            SetCurrentValue(SelectedEndDateProperty, e.Date?.ToDateTime(TimeOnly.MinValue));
             _status.Reset();
             SetCurrentValue(IsDropdownOpenProperty, false);
         }

--- a/src/Ursa/Controls/DateTimePicker/DateTimeHelper.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateTimeHelper.cs
@@ -23,11 +23,21 @@ internal static class DateTimeHelper
         return new DateTime(date.Year, date.Month, 1);
     }
     
+    public static DateOnly GetFirstDayOfMonth(this DateOnly date)
+    {
+        return new DateOnly(date.Year, date.Month, 1);
+    }
+
     public static DateTime GetLastDayOfMonth(this DateTime date)
     {
         return new DateTime(date.Year, date.Month, DateTime.DaysInMonth(date.Year, date.Month));
     }
     
+    public static DateOnly GetLastDayOfMonth(this DateOnly date)
+    {
+        return new DateOnly(date.Year, date.Month, DateTime.DaysInMonth(date.Year, date.Month));
+    }
+
     public static int CompareYearMonth(DateTime dt1, DateTime dt2)
     {
         return (dt1.Year - dt2.Year) * 12 + dt1.Month - dt2.Month;
@@ -53,5 +63,35 @@ internal static class DateTimeHelper
     {
         int start = year / 100 * 100;
         return new ValueTuple<int, int>(start, start + 100);
+    }
+
+    public static DateOnly ToDateOnly(this DateTime date)
+    {
+        return DateOnly.FromDateTime(date);
+    }
+
+    public static DateOnly? ToDateOnly(this DateTime? date)
+    {
+        return date.HasValue ? DateOnly.FromDateTime(date.Value) : null;
+    }
+
+    public static TimeOnly ToTimeOnly(this DateTime date)
+    {
+        return TimeOnly.FromDateTime(date);
+    }
+
+    public static TimeOnly? ToTimeOnly(this TimeSpan? time)
+    {
+        return time.HasValue ? TimeOnly.FromTimeSpan(time.Value) : null;
+    }
+
+    public static DateTime? ToDateTime(this DateOnly? date, TimeOnly time)
+    {
+        return date.HasValue ? date.Value.ToDateTime(time) : null;
+    }
+
+    public static TimeSpan? ToTimeSpan(this TimeOnly? time)
+    {
+        return time?.ToTimeSpan();
     }
 }

--- a/src/Ursa/Controls/DateTimePicker/DateTimeHelper.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateTimeHelper.cs
@@ -85,11 +85,6 @@ internal static class DateTimeHelper
         return time.HasValue ? TimeOnly.FromTimeSpan(time.Value) : null;
     }
 
-    public static DateTime? ToDateTime(this DateOnly? date, TimeOnly time)
-    {
-        return date.HasValue ? date.Value.ToDateTime(time) : null;
-    }
-
     public static TimeSpan? ToTimeSpan(this TimeOnly? time)
     {
         return time?.ToTimeSpan();

--- a/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/DateTimePicker.cs
@@ -114,8 +114,9 @@ public class DateTimePicker : DatePickerBase, IClearControl
         {
             _textBox?.SetValue(TextBox.TextProperty,
                 date.Value.ToString(DisplayFormat ?? CultureInfo.InvariantCulture.DateTimeFormat.FullDateTimePattern));
-            _calendar?.MarkDates(date.Value.Date, date.Value.Date);
-            _timePickerPresenter?.SyncTime(date.Value.TimeOfDay);
+            var selectedDate = date.ToDateOnly();
+            _calendar?.MarkDates(selectedDate, selectedDate);
+            _timePickerPresenter?.SyncTime(date.Value.ToTimeOnly());
         }
     }
 
@@ -183,18 +184,15 @@ public class DateTimePicker : DatePickerBase, IClearControl
         {
             if (e.Date is null) return;
             var date = e.Date.Value;
-            var time = DateTime.Now.TimeOfDay;
-            SetCurrentValue(SelectedDateProperty,
-                new DateTime(date.Year, date.Month, date.Day, time.Hours, time.Minutes, time.Seconds));
+            var time = DateTime.Now.ToTimeOnly();
+            SetCurrentValue(SelectedDateProperty, date.ToDateTime(time));
         }
         else
         {
             var selectedDate = SelectedDate;
             if (e.Date is null) return;
             var date = e.Date.Value;
-            SetCurrentValue(SelectedDateProperty,
-                new DateTime(date.Year, date.Month, date.Day, selectedDate.Value.Hour, selectedDate.Value.Minute,
-                    selectedDate.Value.Second));
+            SetCurrentValue(SelectedDateProperty, date.ToDateTime(selectedDate.Value.ToTimeOnly()));
         }
     }
 
@@ -204,19 +202,14 @@ public class DateTimePicker : DatePickerBase, IClearControl
         {
             if (e.NewTime is null) return;
             var time = e.NewTime.Value;
-            var date = DateTime.Today;
-            SetCurrentValue(SelectedDateProperty,
-                new DateTime(date.Year, date.Month, date.Day, time.Hours, time.Minutes, time.Seconds));
+            SetCurrentValue(SelectedDateProperty, DateTime.Today.ToDateOnly().ToDateTime(time));
         }
         else
         {
             var selectedDate = SelectedDate;
             if (e.NewTime is null) return;
             var time = e.NewTime.Value;
-            SetCurrentValue(SelectedDateProperty,
-                new DateTime(selectedDate.Value.Year, selectedDate.Value.Month, selectedDate.Value.Day, time.Hours,
-                    time.Minutes,
-                    time.Seconds));
+            SetCurrentValue(SelectedDateProperty, selectedDate.Value.ToDateOnly().ToDateTime(time));
         }
     }
 
@@ -230,7 +223,7 @@ public class DateTimePicker : DatePickerBase, IClearControl
     {
         var startDate = SelectedDate ?? DateTime.Today;
         _calendar?.SyncContextDate(new DatePickerCalendarContext(startDate.Year, startDate.Month));
-        var time = SelectedDate?.TimeOfDay;
+        var time = SelectedDate?.ToTimeOnly();
         _timePickerPresenter?.SyncTime(time);
     }
 

--- a/src/Ursa/Controls/DateTimePicker/TimeChangedEventArgs.cs
+++ b/src/Ursa/Controls/DateTimePicker/TimeChangedEventArgs.cs
@@ -4,11 +4,11 @@ namespace Ursa.Controls;
 
 public class TimeChangedEventArgs:RoutedEventArgs
 {
-    public TimeSpan? OldTime { get; }
+    public TimeOnly? OldTime { get; }
 
-    public TimeSpan? NewTime { get; }
+    public TimeOnly? NewTime { get; }
 
-    public TimeChangedEventArgs(TimeSpan? oldTime, TimeSpan? newTime)
+    public TimeChangedEventArgs(TimeOnly? oldTime, TimeOnly? newTime)
     {
         this.OldTime = oldTime;
         this.NewTime = newTime;

--- a/src/Ursa/Controls/DateTimePicker/TimePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/TimePicker.cs
@@ -136,14 +136,14 @@ public class TimePicker : TimePickerBase, IClearControl
     private void InitializePopupOpen()
     {
         SetCurrentValue(IsDropdownOpenProperty, true);
-        _presenter?.SyncTime(SelectedTime);
+        _presenter?.SyncTime(SelectedTime.ToTimeOnly());
     }
 
     private void OnPresenterTimeChanged(object? sender, TimeChangedEventArgs e)
     {
         if (!IsInitialized) return;
         if (_suppressTextPresenterEvent) return;
-        SetCurrentValue(SelectedTimeProperty, e.NewTime);
+        SetCurrentValue(SelectedTimeProperty, e.NewTime.ToTimeSpan());
     }
 
     private void OnTextBoxGetFocus(object? sender, FocusChangedEventArgs e)
@@ -188,7 +188,7 @@ public class TimePicker : TimePickerBase, IClearControl
     {
         if (_textBox is null) return;
         _suppressTextPresenterEvent = true;
-        _presenter?.SyncTime(args.NewValue.Value);
+        _presenter?.SyncTime(args.NewValue.Value.ToTimeOnly());
         SyncTimeToText(args.NewValue.Value);
         _suppressTextPresenterEvent = false;
     }
@@ -202,8 +202,7 @@ public class TimePicker : TimePickerBase, IClearControl
             return;
         }
 
-        var date = new DateTime(1, 1, 1, time.Value.Hours, time.Value.Minutes, time.Value.Seconds);
-        var text = date.ToString(DisplayFormat);
+        var text = TimeOnly.FromTimeSpan(time.Value).ToString(DisplayFormat);
         _textBox.Text = text;
     }
 
@@ -247,11 +246,11 @@ public class TimePicker : TimePickerBase, IClearControl
             SetCurrentValue(SelectedTimeProperty, null);
             return;
         }
-        else if (DateTime.TryParseExact(_textBox?.Text, format, CultureInfo.CurrentUICulture, DateTimeStyles.None,
+        else if (TimeOnly.TryParseExact(_textBox?.Text, format, CultureInfo.CurrentUICulture, DateTimeStyles.None,
                 out var time))
         {
-            SetCurrentValue(SelectedTimeProperty, time.TimeOfDay);
-            _presenter?.SyncTime(time.TimeOfDay);
+            SetCurrentValue(SelectedTimeProperty, time.ToTimeSpan());
+            _presenter?.SyncTime(time);
         }
         else
         {

--- a/src/Ursa/Controls/DateTimePicker/TimePickerPresenter.cs
+++ b/src/Ursa/Controls/DateTimePicker/TimePickerPresenter.cs
@@ -75,7 +75,7 @@ public class TimePickerPresenter : TemplatedControl
     private bool _surpressTimeEvent = true;
     private Control? _thirdSeparator;
     private bool _use12Clock;
-    internal TimeSpan? TimeHolder;
+    internal TimeOnly? TimeHolder;
 
     static TimePickerPresenter()
     {
@@ -230,11 +230,11 @@ public class TimePickerPresenter : TemplatedControl
     {
         if (_surpressTimeEvent) return;
         if (!_use12Clock && Equals(sender, _ampmSelector)) return;
-        var time = TimeHolder ?? DateTime.Now.TimeOfDay;
-        var hour = _hourSelector?.SelectedValue ?? time.Hours;
-        var minute = _minuteSelector?.SelectedValue ?? time.Minutes;
-        var second = _secondSelector?.SelectedValue ?? time.Seconds;
-        var ampm = _ampmSelector?.SelectedValue ?? (time.Hours >= 12 ? 1 : 0);
+        var time = TimeHolder ?? DateTime.Now.ToTimeOnly();
+        var hour = _hourSelector?.SelectedValue ?? time.Hour;
+        var minute = _minuteSelector?.SelectedValue ?? time.Minute;
+        var second = _secondSelector?.SelectedValue ?? time.Second;
+        var ampm = _ampmSelector?.SelectedValue ?? (time.Hour >= 12 ? 1 : 0);
         if (_use12Clock)
         {
             hour = ampm switch
@@ -254,7 +254,7 @@ public class TimePickerPresenter : TemplatedControl
             SetIfChanged(_ampmSelector, ampm);
         }
 
-        var newTime = new TimeSpan(hour, minute, second);
+        var newTime = new TimeOnly(hour, minute, second);
         if (NeedsConfirmation)
         {
             TimeHolder = newTime;
@@ -272,19 +272,19 @@ public class TimePickerPresenter : TemplatedControl
         OnPanelSelectionChanged(null, System.EventArgs.Empty);
     }
 
-    private void UpdatePanelsFromSelectedTime(TimeSpan? time)
+    private void UpdatePanelsFromSelectedTime(TimeOnly? time)
     {
         if (time is null) return;
         if (_hourSelector is not null)
         {
-            var index = _use12Clock ? time.Value.Hours % 12 : time.Value.Hours;
+            var index = _use12Clock ? time.Value.Hour % 12 : time.Value.Hour;
             if (_use12Clock && index == 0) index = 12;
             SetIfChanged(_hourSelector, index, true);
         }
 
-        SetIfChanged(_minuteSelector, time.Value.Minutes, true);
-        SetIfChanged(_secondSelector, time.Value.Seconds, true);
-        var ampm = time.Value.Hours switch
+        SetIfChanged(_minuteSelector, time.Value.Minute, true);
+        SetIfChanged(_secondSelector, time.Value.Second, true);
+        var ampm = time.Value.Hour switch
         {
             >= 12 => 1,
             _ => 0
@@ -340,7 +340,7 @@ public class TimePickerPresenter : TemplatedControl
         panel.SelectionChanged += OnPanelSelectionChanged;
     }
 
-    internal void SyncTime(TimeSpan? time)
+    internal void SyncTime(TimeOnly? time)
     {
         _surpressTimeEvent = true;
         TimeHolder = time;

--- a/src/Ursa/Controls/DateTimePicker/TimeRangePicker.cs
+++ b/src/Ursa/Controls/DateTimePicker/TimeRangePicker.cs
@@ -154,11 +154,11 @@ public class TimeRangePicker : TimePickerBase, IClearControl
         SyncTimeToText(time, start);
         if (start)
         {
-            _startPresenter?.SyncTime(time);
+            _startPresenter?.SyncTime(time.ToTimeOnly());
         }
         else
         {
-            _endPresenter?.SyncTime(time);
+            _endPresenter?.SyncTime(time.ToTimeOnly());
         }
         PseudoClasses.Set(PseudoClassName.PC_Empty, SelectedStartTime is null && SelectedEndTime is null);
     }
@@ -173,8 +173,7 @@ public class TimeRangePicker : TimePickerBase, IClearControl
             return;
         }
 
-        var date = new DateTime(1, 1, 1, time.Value.Hours, time.Value.Minutes, time.Value.Seconds);
-        var text = date.ToString(DisplayFormat ?? DEFAULT_TIME_DISPLAY_FORMAT);
+        var text = TimeOnly.FromTimeSpan(time.Value).ToString(DisplayFormat ?? DEFAULT_TIME_DISPLAY_FORMAT);
         textBox.Text = text;
         PseudoClasses.Set(PseudoClassName.PC_Empty, SelectedStartTime is null && SelectedEndTime is null);
     }
@@ -200,8 +199,8 @@ public class TimeRangePicker : TimePickerBase, IClearControl
         PointerPressedEvent.AddHandler(OnTextBoxPressed, RoutingStrategies.Tunnel, true, _startTextBox, _endTextBox);
         LostFocusEvent.AddHandler(OnTextBoxLostFocus, _startTextBox, _endTextBox); 
 
-        _startPresenter?.SyncTime(SelectedStartTime);
-        _endPresenter?.SyncTime(SelectedEndTime);
+        _startPresenter?.SyncTime(SelectedStartTime.ToTimeOnly());
+        _endPresenter?.SyncTime(SelectedEndTime.ToTimeOnly());
         SyncTimeToText(SelectedStartTime);
         SyncTimeToText(SelectedEndTime, false);
     }
@@ -232,19 +231,19 @@ public class TimeRangePicker : TimePickerBase, IClearControl
         {
             _status.Push(Status.End);
         }
-        _startPresenter?.SyncTime(SelectedStartTime);
-        _endPresenter?.SyncTime(SelectedEndTime);
+        _startPresenter?.SyncTime(SelectedStartTime.ToTimeOnly());
+        _endPresenter?.SyncTime(SelectedEndTime.ToTimeOnly());
     }
 
     private void OnTimeSelected(object? sender, TimeChangedEventArgs e)
     {
         if (Equals(sender, _startPresenter))
         {
-            SetCurrentValue(SelectedStartTimeProperty, e.NewTime);
+            SetCurrentValue(SelectedStartTimeProperty, e.NewTime.ToTimeSpan());
         }
         else if (Equals(sender, _endPresenter))
         {
-            SetCurrentValue(SelectedEndTimeProperty, e.NewTime);
+            SetCurrentValue(SelectedEndTimeProperty, e.NewTime.ToTimeSpan());
         }
     }
 
@@ -330,9 +329,9 @@ public class TimeRangePicker : TimePickerBase, IClearControl
             startDate = null;
             SetCurrentValue(SelectedStartTimeProperty, startDate);
         }
-        else if (TimeSpan.TryParseExact(_startTextBox?.Text, format, CultureInfo.CurrentUICulture, out var start))
+        else if (TimeOnly.TryParseExact(_startTextBox?.Text, format, CultureInfo.CurrentUICulture, DateTimeStyles.None, out var start))
         {
-            startDate = start;
+            startDate = start.ToTimeSpan();
             SetCurrentValue(SelectedStartTimeProperty, startDate);
         }
         else
@@ -345,17 +344,17 @@ public class TimeRangePicker : TimePickerBase, IClearControl
             endDate = null;
             SetCurrentValue(SelectedEndTimeProperty, endDate);
         }
-        else if (TimeSpan.TryParseExact(_endTextBox?.Text, format, CultureInfo.CurrentUICulture, out var end))
+        else if (TimeOnly.TryParseExact(_endTextBox?.Text, format, CultureInfo.CurrentUICulture, DateTimeStyles.None, out var end))
         {
-            endDate = end;
+            endDate = end.ToTimeSpan();
             SetCurrentValue(SelectedEndTimeProperty, endDate);
         }
         else
         {
             SetCurrentValue(SelectedEndTimeProperty, null);
         }
-        _startPresenter?.SyncTime(SelectedStartTime);
-        _endPresenter?.SyncTime(SelectedEndTime);
+        _startPresenter?.SyncTime(SelectedStartTime.ToTimeOnly());
+        _endPresenter?.SyncTime(SelectedEndTime.ToTimeOnly());
     }
     
     protected override void OnPointerPressed(PointerPressedEventArgs e)

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePicker/DatePickerCalendarDayButtonTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePicker/DatePickerCalendarDayButtonTests.cs
@@ -15,13 +15,13 @@ public class DatePickerCalendarDayButtonTests
     {
         Window window = new Window();
         var button = new DatePickerCalendarDayButton();
-        var date = new DateTime(2023, 5, 15);
+        var date = new DateOnly(2023, 5, 15);
         button.DataContext = date;
         window.Content = button;
         window.Show();
         Dispatcher.UIThread.RunJobs();
         int eventRaised = 0;
-        DateTime? eventContext = null;
+        DateOnly? eventContext = null;
 
         void OnMouseClick(object? sender, DatePickerCalendarDayButtonEventArgs args)
         {
@@ -45,13 +45,13 @@ public class DatePickerCalendarDayButtonTests
     {
         Window window = new Window();
         var button = new DatePickerCalendarDayButton();
-        var date = new DateTime(2023, 5, 15);
+        var date = new DateOnly(2023, 5, 15);
         button.DataContext = date;
         window.Content = button;
         window.Show();
         Dispatcher.UIThread.RunJobs();
         int eventRaised = 0;
-        DateTime? eventContext = null;
+        DateOnly? eventContext = null;
 
         void OnMouseEnter(object? sender, DatePickerCalendarDayButtonEventArgs args)
         {

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePicker/DatePickerCalendarViewTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePicker/DatePickerCalendarViewTests.cs
@@ -264,7 +264,7 @@ public class DatePickerCalendarViewTests
         Assert.NotNull(dayHeader);
         Assert.NotNull(dayButton);
         Assert.Equal('S', dayHeader.Text?[0]);
-        Assert.Equal(30, (dayButton.DataContext as DateTime?)?.Day);
+        Assert.Equal(30, (dayButton.DataContext as DateOnly?)?.Day);
         
         calendarView.FirstDayOfWeek = DayOfWeek.Tuesday;
         
@@ -273,7 +273,7 @@ public class DatePickerCalendarViewTests
         Assert.NotNull(dayHeader);
         Assert.NotNull(dayButton);
         Assert.Equal('T', dayHeader.Text?[0]);
-        Assert.Equal(25, (dayButton.DataContext as DateTime?)?.Day);
+        Assert.Equal(25, (dayButton.DataContext as DateOnly?)?.Day);
         
     }
     

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePicker/DatePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePicker/DatePickerTests.cs
@@ -176,7 +176,7 @@ public class DatePickerTests
         Dispatcher.UIThread.RunJobs();
         var popup = picker.GetTemplateChildOfType<Popup>(DatePicker.PART_Popup);
         var calendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
-        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateTime(2025, 2, 17))
+        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateOnly(2025, 2, 17))
             { RoutedEvent = DatePickerCalendarView.DateSelectedEvent }); 
         Dispatcher.UIThread.RunJobs();
         var textBox = picker.GetTemplateChildOfType<TextBox>(DatePicker.PART_TextBox);
@@ -203,7 +203,7 @@ public class DatePickerTests
         Dispatcher.UIThread.RunJobs();
         var popup = picker.GetTemplateChildOfType<Popup>(DatePicker.PART_Popup);
         var calendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
-        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateTime(2025, 2, 17))
+        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateOnly(2025, 2, 17))
             { RoutedEvent = DatePickerCalendarView.DateSelectedEvent }); 
         Dispatcher.UIThread.RunJobs();
         var textBox = picker.GetTemplateChildOfType<TextBox>(DatePicker.PART_TextBox);

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePicker/TimePickerPresenterTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePicker/TimePickerPresenterTests.cs
@@ -25,7 +25,7 @@ public class TimePickerPresenterTests
     public void TimePickerPresenter_SetTime_ShouldUpdateTimeProperty()
     {
         var presenter = new TimePickerPresenter();
-        var time = new TimeSpan(10, 30, 45);
+        var time = new TimeOnly(10, 30, 45);
 
         presenter.TimeHolder = time;
 
@@ -81,9 +81,9 @@ public class TimePickerPresenterTests
     public void TimePickerPresenter_Confirm_ShouldSetTimeProperty()
     {
         var presenter = new TimePickerPresenter { NeedsConfirmation = true };
-        var time = new TimeSpan(10, 30, 45);
+        var time = new TimeOnly(10, 30, 45);
         var eventRaised = 0;
-        TimeSpan? eventResult = null;
+        TimeOnly? eventResult = null;
         presenter.SelectedTimeChanged += (o, e) =>
         {
             eventRaised++;
@@ -104,8 +104,8 @@ public class TimePickerPresenterTests
     public void TimePickerPresenter_SyncTime_Should_Not_RaiseEvent()
     {
         var presenter = new TimePickerPresenter();
-        var oldTime = new TimeSpan(10, 30, 45);
-        var newTime = new TimeSpan(11, 45, 30);
+        var oldTime = new TimeOnly(10, 30, 45);
+        var newTime = new TimeOnly(11, 45, 30);
         presenter.SyncTime(oldTime);
         var eventRaised = false;
         presenter.SelectedTimeChanged += (sender, args) =>
@@ -119,7 +119,7 @@ public class TimePickerPresenterTests
 
     [AvaloniaTheory]
     [MemberData(nameof(GetSelectionMemberData))]
-    public void TimePickerPresenter_Time_Updated_When_Panel_Selection_Changed(string format, int hourSelection, int minuteSelection, int secondSelection, int amSelection, TimeSpan expectedTime)
+    public void TimePickerPresenter_Time_Updated_When_Panel_Selection_Changed(string format, int hourSelection, int minuteSelection, int secondSelection, int amSelection, TimeOnly expectedTime)
     {
         var window = new Window();
         var presenter = new TimePickerPresenter();
@@ -127,7 +127,7 @@ public class TimePickerPresenterTests
         window.Show();
         Dispatcher.UIThread.RunJobs();
         presenter.PanelFormat = format;
-        TimeSpan? eventResult = null;
+        TimeOnly? eventResult = null;
         presenter.SelectedTimeChanged += (o, e) =>
         {
             eventResult = e.NewTime;
@@ -154,7 +154,7 @@ public class TimePickerPresenterTests
     
     [AvaloniaTheory]
     [MemberData(nameof(GetSelectionMemberData))]
-    public void TimePickerPresenter_TimeHolder_Updated_When_Panel_Selection_Changed(string format, int hourSelection, int minuteSelection, int secondSelection, int amSelection, TimeSpan expectedTime)
+    public void TimePickerPresenter_TimeHolder_Updated_When_Panel_Selection_Changed(string format, int hourSelection, int minuteSelection, int secondSelection, int amSelection, TimeOnly expectedTime)
     {
         var window = new Window();
         var presenter = new TimePickerPresenter(){NeedsConfirmation = true};
@@ -184,12 +184,12 @@ public class TimePickerPresenterTests
 
     public static IEnumerable<object[]> GetSelectionMemberData()
     {
-        yield return new object[] { "hh mm ss t", 1, 1, 1, 1, new TimeSpan(0, 13, 1, 1) };
-        yield return new object[] { "HH mm ss t", 12, 30, 45, 0, new TimeSpan(0, 12,30,45)};
-        yield return new object[] { "HH mm ss t", 12, 0, 0, 1, new TimeSpan(0, 12,0,0)};
-        yield return new object[] { "HH mm ss t", 13, 0, 0, 1, new TimeSpan(0, 13,0,0)};
-        yield return new object[] { "hh mm ss t", 9, 0, 0, 0, new TimeSpan(0, 9,0,0)};
-        yield return new object[] { "hh mm ss t", 9, 0, 0, 1, new TimeSpan(0, 21,0,0)};
-        yield return new object[] { "HH mm ss t", 0, 0, 0, 0, new TimeSpan(0, 0,0,0)};
+        yield return new object[] { "hh mm ss t", 1, 1, 1, 1, new TimeOnly(13, 1, 1) };
+        yield return new object[] { "HH mm ss t", 12, 30, 45, 0, new TimeOnly(12, 30, 45) };
+        yield return new object[] { "HH mm ss t", 12, 0, 0, 1, new TimeOnly(12, 0, 0) };
+        yield return new object[] { "HH mm ss t", 13, 0, 0, 1, new TimeOnly(13, 0, 0) };
+        yield return new object[] { "hh mm ss t", 9, 0, 0, 0, new TimeOnly(9, 0, 0) };
+        yield return new object[] { "hh mm ss t", 9, 0, 0, 1, new TimeOnly(21, 0, 0) };
+        yield return new object[] { "HH mm ss t", 0, 0, 0, 0, new TimeOnly(0, 0, 0) };
     }
 }


### PR DESCRIPTION
This is the most precise data type to represent the actual usage of two presenters. 
This is also for the potential change of DateTimeOffset picker series. 