### PR TITLE
Make Tags nullable in TagInput

### DIFF
--- a/src/Ursa/Controls/AutoCompleteBox/AutoCompleteBox.cs
+++ b/src/Ursa/Controls/AutoCompleteBox/AutoCompleteBox.cs
@@ -87,6 +87,11 @@ public class AutoCompleteBox : Avalonia.Controls.AutoCompleteBox, IClearControl
             var value = change.GetNewValue<string?>();
             PseudoClasses.Set(PseudoClassName.PC_Empty, string.IsNullOrEmpty(value));
         }
+
+        if (change.Property == IsDropDownOpenProperty && change.GetNewValue<bool>() == false)
+        {
+            
+        }
     }
 
     protected override void OnLostFocus(FocusChangedEventArgs e)

--- a/src/Ursa/Controls/TagInput/TagInput.cs
+++ b/src/Ursa/Controls/TagInput/TagInput.cs
@@ -25,8 +25,8 @@ public class TagInput : TemplatedControl
     public const string PART_ItemsControl = "PART_ItemsControl";
     public const string PART_Placeholder = "PART_Placeholder";
 
-    public static readonly StyledProperty<IList<string>> TagsProperty =
-        AvaloniaProperty.Register<TagInput, IList<string>>(
+    public static readonly StyledProperty<IList<string>?> TagsProperty =
+        AvaloniaProperty.Register<TagInput, IList<string>?>(
             nameof(Tags));
 
     public static readonly StyledProperty<string?> PlaceholderTextProperty =
@@ -99,7 +99,7 @@ public class TagInput : TemplatedControl
         set => PlaceholderText = value;
     }
 
-    public IList<string> Tags
+    public IList<string>? Tags
     {
         get => GetValue(TagsProperty);
         set => SetValue(TagsProperty, value);
@@ -201,7 +201,7 @@ public class TagInput : TemplatedControl
     private void CheckEmpty()
     {
         if (string.IsNullOrWhiteSpace(_presenter?.PreeditText) && string.IsNullOrEmpty(InputTextBox?.Text) &&
-            Tags.Count == 0)
+            (Tags is null || Tags.Count == 0))
             PseudoClasses.Set(PseudoClassName.PC_Empty, true);
         else
             PseudoClasses.Set(PseudoClassName.PC_Empty, false);
@@ -227,7 +227,7 @@ public class TagInput : TemplatedControl
         {
             if (string.IsNullOrEmpty(InputTextBox?.Text))
             {
-                if (Tags.Count == 0) return;
+                if (Tags is null || Tags.Count == 0) return;
                 Tags.RemoveAt(Tags.Count - 1);
             }
         }
@@ -236,6 +236,7 @@ public class TagInput : TemplatedControl
     private void AddTags(string? text)
     {
         if (!(text?.Length > 0)) return;
+        if (Tags is null) return;
         if (Tags.Count >= MaxCount) return;
         string[] values = [];
         if (!string.IsNullOrEmpty(Separator))
@@ -257,6 +258,7 @@ public class TagInput : TemplatedControl
     public void Close(object o)
     {
         if (o is not ClosableTag presenter) return;
+        if (Tags is null) return;
         var index = _itemsControl?.IndexFromContainer(presenter);
         if (index is >= 0 && index < Tags.Count)
             Tags.RemoveAt(index.Value);

--- a/tests/Directory.Packages.props
+++ b/tests/Directory.Packages.props
@@ -12,7 +12,7 @@
         <PackageVersion Include="Avalonia.HarfBuzz" Version="$(AvaloniaVersion)"/>
         <PackageVersion Include="Avalonia.Skia" Version="$(AvaloniaVersion)"/>
         <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
-        <PackageVersion Include="Semi.Avalonia" Version="12.0.0"/>
+        <PackageVersion Include="Semi.Avalonia" Version="12.0.1"/>
         <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.13.1"/>
     </ItemGroup>
 </Project>

--- a/tests/HeadlessTest.Ursa/Controls/AutoCompleteBoxTests/Tests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/AutoCompleteBoxTests/Tests.cs
@@ -21,6 +21,7 @@ public class Tests
             VerticalAlignment = VerticalAlignment.Top,
             Width = 100,
             Height = 100,
+            ItemsSource = new List<string> {"Hello", "World"}
         };
         var textBox = new TextBox()
         {


### PR DESCRIPTION
On control attaching or detaching from visual tree, there is a chance that Tags is set to null. better to just switch this property to nullable. 