### PR TITLE
test: add headless tests for DateOnly and TimeOnly pickers

### DIFF
--- a/src/Ursa/Controls/DateTimePicker/Base/DateRangePickerBaseT.cs
+++ b/src/Ursa/Controls/DateTimePicker/Base/DateRangePickerBaseT.cs
@@ -173,6 +173,39 @@ public abstract class DateRangePickerBase<T> : DateRangePickerBase where T : str
         _endCalendar?.SyncContextDate(new DatePickerCalendarContext(endDateOnly.Year, endDateOnly.Month));
     }
 
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            SetCurrentValue(IsDropdownOpenProperty, false);
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Down)
+        {
+            SetCurrentValue(IsDropdownOpenProperty, true);
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Tab)
+        {
+            if (Equals(e.Source, _endTextBox)) SetCurrentValue(IsDropdownOpenProperty, false);
+            return;
+        }
+
+        if (e.Key == Key.Enter)
+        {
+            SetCurrentValue(IsDropdownOpenProperty, false);
+            CommitInput();
+            e.Handled = true;
+            return;
+        }
+
+        base.OnKeyDown(e);
+    }
+
     protected override void OnLostFocus(FocusChangedEventArgs e)
     {
         base.OnLostFocus(e);

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/DateOnlyPickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/DateOnlyPickerTests.cs
@@ -1,0 +1,219 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using HeadlessTest.Ursa.TestHelpers;
+using Ursa.Controls;
+
+namespace HeadlessTest.Ursa.Controls.DateTimePickerTests;
+
+public class DateOnlyPickerTests
+{
+    private static DateOnlyPicker CreatePicker() => new()
+    {
+        Width = 300,
+        DisplayFormat = "yyyy-MM-dd",
+        HorizontalAlignment = HorizontalAlignment.Left,
+        VerticalAlignment = VerticalAlignment.Top
+    };
+
+    [AvaloniaFact]
+    public void Click_Opens_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(picker.IsDropdownOpen);
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Click_Button_Toggles_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+
+        var button = picker.GetTemplateChildOfType<PathIcon>("PART_Button");
+        var position = button?.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+
+        Assert.False(picker.IsDropdownOpen);
+        Dispatcher.UIThread.RunJobs();
+        window.MouseDown(position.Value, MouseButton.Left);
+        window.MouseUp(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+
+        window.MouseDown(position.Value, MouseButton.Left);
+        window.MouseUp(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Clear_Sets_SelectedDate_To_Null()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+
+        picker.SelectedDate = new DateOnly(2025, 6, 15);
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedDate);
+
+        picker.Clear();
+        Dispatcher.UIThread.RunJobs();
+        Assert.Null(picker.SelectedDate);
+    }
+
+    [AvaloniaFact]
+    public void Press_Escape_Closes_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+
+        window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+        Assert.False(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Press_Down_Opens_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(picker.IsDropdownOpen);
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        window.KeyPressQwerty(PhysicalKey.ArrowDown, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Press_Tab_Closes_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = new StackPanel
+        {
+            Children =
+            {
+                picker,
+                new TextBox(),
+            }
+        };
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+
+        window.KeyPressQwerty(PhysicalKey.Tab, RawInputModifiers.None);
+        Assert.False(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Set_SelectedDate_Updates_TextBox()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var textBox = picker.GetTemplateChildOfType<TextBox>(DatePickerBase.PART_TextBox);
+        picker.SelectedDate = new DateOnly(2025, 3, 21);
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal("2025-03-21", textBox?.Text);
+    }
+
+    [AvaloniaFact]
+    public void Set_SelectedDate_To_Null_Clears_TextBox()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedDate = new DateOnly(2025, 3, 21);
+        Dispatcher.UIThread.RunJobs();
+        var textBox = picker.GetTemplateChildOfType<TextBox>(DatePickerBase.PART_TextBox);
+        Assert.NotNull(textBox);
+        Assert.Equal("2025-03-21", textBox.Text);
+
+        picker.SelectedDate = null;
+        Dispatcher.UIThread.RunJobs();
+        Assert.Null(textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void SelectedDate_Set_Via_Calendar_Updates_TextBox()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        var popup = picker.GetTemplateChildOfType<Popup>(DatePickerBase.PART_Popup);
+        var calendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
+        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateOnly(2025, 7, 4))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+
+        var textBox = picker.GetTemplateChildOfType<TextBox>(DatePickerBase.PART_TextBox);
+        Assert.NotNull(textBox);
+        Assert.Equal("2025-07-04", textBox.Text);
+        Assert.False(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void SelectedDate_Set_Via_Calendar_Sets_SelectedDate()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        var popup = picker.GetTemplateChildOfType<Popup>(DatePickerBase.PART_Popup);
+        var calendar = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().FirstOrDefault();
+        calendar?.RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateOnly(2025, 7, 4))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(new DateOnly(2025, 7, 4), picker.SelectedDate);
+    }
+}

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/DateOnlyRangePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/DateOnlyRangePickerTests.cs
@@ -1,0 +1,184 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.LogicalTree;
+using Avalonia.Threading;
+using HeadlessTest.Ursa.TestHelpers;
+using Ursa.Controls;
+
+namespace HeadlessTest.Ursa.Controls.DateTimePickerTests;
+
+public class DateOnlyRangePickerTests
+{
+    private static DateOnlyRangePicker CreatePicker() => new()
+    {
+        Width = 500,
+        DisplayFormat = "yyyy-MM-dd",
+        HorizontalAlignment = HorizontalAlignment.Left,
+        VerticalAlignment = VerticalAlignment.Top
+    };
+
+    [AvaloniaFact]
+    public void Set_SelectedDates_Update_TextBoxes()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedStartDate = new DateOnly(2025, 1, 10);
+        picker.SelectedEndDate = new DateOnly(2025, 1, 20);
+        Dispatcher.UIThread.RunJobs();
+
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePickerBase.PART_StartTextBox);
+        var endTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePickerBase.PART_EndTextBox);
+        Assert.NotNull(startTextBox);
+        Assert.NotNull(endTextBox);
+        Assert.Equal("2025-01-10", startTextBox.Text);
+        Assert.Equal("2025-01-20", endTextBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void Clear_Clears_Both_Dates()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedStartDate = new DateOnly(2025, 1, 10);
+        picker.SelectedEndDate = new DateOnly(2025, 1, 20);
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedStartDate);
+        Assert.NotNull(picker.SelectedEndDate);
+
+        picker.Clear();
+        Dispatcher.UIThread.RunJobs();
+        Assert.Null(picker.SelectedStartDate);
+        Assert.Null(picker.SelectedEndDate);
+    }
+
+    [AvaloniaFact]
+    public void Click_StartTextBox_Opens_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePickerBase.PART_StartTextBox);
+        Assert.NotNull(startTextBox);
+        var position = startTextBox.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+
+        Assert.False(picker.IsDropdownOpen);
+        window.MouseDown(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Click_EndTextBox_Opens_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var endTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePickerBase.PART_EndTextBox);
+        Assert.NotNull(endTextBox);
+        var position = endTextBox.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+
+        Assert.False(picker.IsDropdownOpen);
+        window.MouseDown(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Press_Escape_Closes_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePickerBase.PART_StartTextBox);
+        Assert.NotNull(startTextBox);
+        var position = startTextBox.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+
+        window.MouseDown(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+
+        window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+        Assert.False(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Set_SelectedStartDate_To_Null_Clears_Start_TextBox()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedStartDate = new DateOnly(2025, 5, 1);
+        picker.SelectedEndDate = new DateOnly(2025, 5, 31);
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedStartDate = null;
+        Dispatcher.UIThread.RunJobs();
+
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePickerBase.PART_StartTextBox);
+        Assert.NotNull(startTextBox);
+        Assert.True(string.IsNullOrEmpty(startTextBox.Text));
+    }
+
+    [AvaloniaFact]
+    public void Calendar_Date_Selected_Sets_StartDate_Then_EndDate()
+    {
+        var window = new Window { Width = 800, Height = 600 };
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(DateRangePickerBase.PART_StartTextBox);
+        Assert.NotNull(startTextBox);
+        var position = startTextBox.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+
+        window.MouseDown(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        var popup = picker.GetTemplateChildOfType<Popup>(DateRangePickerBase.PART_Popup);
+        var calendars = popup?.GetLogicalDescendants().OfType<DatePickerCalendarView>().ToList();
+        Assert.NotNull(calendars);
+        Assert.NotEmpty(calendars);
+
+        // Select start date
+        calendars[0].RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateOnly(2025, 3, 10))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(new DateOnly(2025, 3, 10), picker.SelectedStartDate);
+
+        // Select end date
+        calendars[0].RaiseEvent(new DatePickerCalendarDayButtonEventArgs(new DateOnly(2025, 3, 20))
+            { RoutedEvent = DatePickerCalendarView.DateSelectedEvent });
+        Dispatcher.UIThread.RunJobs();
+        Assert.Equal(new DateOnly(2025, 3, 20), picker.SelectedEndDate);
+    }
+}

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyPickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyPickerTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.LogicalTree;
 using Avalonia.Threading;
 using HeadlessTest.Ursa.TestHelpers;
 using Ursa.Controls;
@@ -157,7 +158,13 @@ public class TimeOnlyPickerTests
         window.Show();
         Dispatcher.UIThread.RunJobs();
 
-        var presenter = picker.GetTemplateChildOfType<TimePickerPresenter>(TimePickerBase.PART_Presenter);
+        // Open popup so the presenter becomes part of the visual/logical tree
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+
+        var popup = picker.GetTemplateChildOfType<Popup>(TimePickerBase.PART_Popup);
+        var presenter = popup?.GetLogicalDescendants().OfType<TimePickerPresenter>().FirstOrDefault();
         Assert.NotNull(presenter);
 
         var newTime = new TimeOnly(10, 20, 30);

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyPickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyPickerTests.cs
@@ -1,0 +1,169 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using HeadlessTest.Ursa.TestHelpers;
+using Ursa.Controls;
+
+namespace HeadlessTest.Ursa.Controls.DateTimePickerTests;
+
+public class TimeOnlyPickerTests
+{
+    private static TimeOnlyPicker CreatePicker() => new()
+    {
+        Width = 300,
+        DisplayFormat = "HH:mm:ss",
+        HorizontalAlignment = HorizontalAlignment.Left,
+        VerticalAlignment = VerticalAlignment.Top
+    };
+
+    [AvaloniaFact]
+    public void Click_Opens_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(picker.IsDropdownOpen);
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Assert.True(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Click_Button_Toggles_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+
+        var button = picker.GetTemplateChildOfType<PathIcon>("PART_Button");
+        var position = button?.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+
+        Assert.False(picker.IsDropdownOpen);
+        Dispatcher.UIThread.RunJobs();
+        window.MouseDown(position.Value, MouseButton.Left);
+        window.MouseUp(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+
+        window.MouseDown(position.Value, MouseButton.Left);
+        window.MouseUp(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.False(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Clear_Sets_SelectedTime_To_Null()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedTime = new TimeOnly(14, 30, 0);
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedTime);
+
+        picker.Clear();
+        Dispatcher.UIThread.RunJobs();
+        Assert.Null(picker.SelectedTime);
+    }
+
+    [AvaloniaFact]
+    public void Set_SelectedTime_Updates_TextBox()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedTime = new TimeOnly(9, 5, 30);
+        Dispatcher.UIThread.RunJobs();
+
+        var textBox = picker.GetTemplateChildOfType<TextBox>(TimePickerBase.PART_TextBox);
+        Assert.NotNull(textBox);
+        Assert.Equal("09:05:30", textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void Set_SelectedTime_To_Null_Clears_TextBox()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedTime = new TimeOnly(14, 30, 0);
+        Dispatcher.UIThread.RunJobs();
+        var textBox = picker.GetTemplateChildOfType<TextBox>(TimePickerBase.PART_TextBox);
+        Assert.NotNull(textBox);
+        Assert.Equal("14:30:00", textBox.Text);
+
+        picker.SelectedTime = null;
+        Dispatcher.UIThread.RunJobs();
+        Assert.Null(textBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void Press_Escape_Closes_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        Assert.True(picker.IsDropdownOpen);
+
+        window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+        Assert.False(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Press_Down_Opens_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.False(picker.IsDropdownOpen);
+        window.MouseDown(new Point(10, 10), MouseButton.Left);
+        window.KeyPressQwerty(PhysicalKey.ArrowDown, RawInputModifiers.None);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Presenter_Time_Change_Updates_SelectedTime()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var presenter = picker.GetTemplateChildOfType<TimePickerPresenter>(TimePickerBase.PART_Presenter);
+        Assert.NotNull(presenter);
+
+        var newTime = new TimeOnly(10, 20, 30);
+        presenter.RaiseEvent(new TimeChangedEventArgs(null, newTime)
+            { RoutedEvent = TimePickerPresenter.SelectedTimeChangedEvent });
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(newTime, picker.SelectedTime);
+    }
+}

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyPickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyPickerTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Layout;
 using Avalonia.Threading;
 using HeadlessTest.Ursa.TestHelpers;
 using Ursa.Controls;
+using TimePickerPresenter = Ursa.Controls.TimePickerPresenter;
 
 namespace HeadlessTest.Ursa.Controls.DateTimePickerTests;
 

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyRangePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyRangePickerTests.cs
@@ -5,6 +5,7 @@ using Avalonia.Headless;
 using Avalonia.Headless.XUnit;
 using Avalonia.Input;
 using Avalonia.Layout;
+using Avalonia.LogicalTree;
 using Avalonia.Threading;
 using HeadlessTest.Ursa.TestHelpers;
 using Ursa.Controls;
@@ -142,7 +143,9 @@ public class TimeOnlyRangePickerTests
         window.MouseDown(position.Value, MouseButton.Left);
         Dispatcher.UIThread.RunJobs();
 
-        var startPresenter = picker.GetTemplateChildOfType<TimePickerPresenter>(TimeRangePickerBase.PART_StartPresenter);
+        var popup = picker.GetTemplateChildOfType<Popup>(TimeRangePickerBase.PART_Popup);
+        var startPresenter = popup?.GetLogicalDescendants().OfType<TimePickerPresenter>()
+            .FirstOrDefault(p => p.Name == TimeRangePickerBase.PART_StartPresenter);
         Assert.NotNull(startPresenter);
 
         var newTime = new TimeOnly(9, 15, 0);
@@ -169,7 +172,9 @@ public class TimeOnlyRangePickerTests
         window.MouseDown(position.Value, MouseButton.Left);
         Dispatcher.UIThread.RunJobs();
 
-        var endPresenter = picker.GetTemplateChildOfType<TimePickerPresenter>(TimeRangePickerBase.PART_EndPresenter);
+        var popup = picker.GetTemplateChildOfType<Popup>(TimeRangePickerBase.PART_Popup);
+        var endPresenter = popup?.GetLogicalDescendants().OfType<TimePickerPresenter>()
+            .FirstOrDefault(p => p.Name == TimeRangePickerBase.PART_EndPresenter);
         Assert.NotNull(endPresenter);
 
         var newTime = new TimeOnly(18, 45, 0);

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyRangePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyRangePickerTests.cs
@@ -8,6 +8,7 @@ using Avalonia.Layout;
 using Avalonia.Threading;
 using HeadlessTest.Ursa.TestHelpers;
 using Ursa.Controls;
+using TimePickerPresenter = Ursa.Controls.TimePickerPresenter;
 
 namespace HeadlessTest.Ursa.Controls.DateTimePickerTests;
 

--- a/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyRangePickerTests.cs
+++ b/tests/HeadlessTest.Ursa/Controls/DateTimePickerTests/TimeOnlyRangePickerTests.cs
@@ -1,0 +1,181 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Headless;
+using Avalonia.Headless.XUnit;
+using Avalonia.Input;
+using Avalonia.Layout;
+using Avalonia.Threading;
+using HeadlessTest.Ursa.TestHelpers;
+using Ursa.Controls;
+
+namespace HeadlessTest.Ursa.Controls.DateTimePickerTests;
+
+public class TimeOnlyRangePickerTests
+{
+    private static TimeOnlyRangePicker CreatePicker() => new()
+    {
+        Width = 500,
+        DisplayFormat = "HH:mm:ss",
+        HorizontalAlignment = HorizontalAlignment.Left,
+        VerticalAlignment = VerticalAlignment.Top
+    };
+
+    [AvaloniaFact]
+    public void Set_SelectedTimes_Update_TextBoxes()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedStartTime = new TimeOnly(8, 0, 0);
+        picker.SelectedEndTime = new TimeOnly(17, 30, 0);
+        Dispatcher.UIThread.RunJobs();
+
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(TimeRangePickerBase.PART_StartTextBox);
+        var endTextBox = picker.GetTemplateChildOfType<TextBox>(TimeRangePickerBase.PART_EndTextBox);
+        Assert.NotNull(startTextBox);
+        Assert.NotNull(endTextBox);
+        Assert.Equal("08:00:00", startTextBox.Text);
+        Assert.Equal("17:30:00", endTextBox.Text);
+    }
+
+    [AvaloniaFact]
+    public void Clear_Clears_Both_Times()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        picker.SelectedStartTime = new TimeOnly(8, 0, 0);
+        picker.SelectedEndTime = new TimeOnly(17, 30, 0);
+        Dispatcher.UIThread.RunJobs();
+        Assert.NotNull(picker.SelectedStartTime);
+        Assert.NotNull(picker.SelectedEndTime);
+
+        picker.Clear();
+        Dispatcher.UIThread.RunJobs();
+        Assert.Null(picker.SelectedStartTime);
+        Assert.Null(picker.SelectedEndTime);
+    }
+
+    [AvaloniaFact]
+    public void Click_StartTextBox_Opens_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(TimeRangePickerBase.PART_StartTextBox);
+        Assert.NotNull(startTextBox);
+        var position = startTextBox.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+
+        Assert.False(picker.IsDropdownOpen);
+        window.MouseDown(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Click_EndTextBox_Opens_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var endTextBox = picker.GetTemplateChildOfType<TextBox>(TimeRangePickerBase.PART_EndTextBox);
+        Assert.NotNull(endTextBox);
+        var position = endTextBox.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+
+        Assert.False(picker.IsDropdownOpen);
+        window.MouseDown(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Press_Escape_Closes_Popup()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(TimeRangePickerBase.PART_StartTextBox);
+        Assert.NotNull(startTextBox);
+        var position = startTextBox.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+
+        window.MouseDown(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+        Assert.True(picker.IsDropdownOpen);
+
+        window.KeyPressQwerty(PhysicalKey.Escape, RawInputModifiers.None);
+        Assert.False(picker.IsDropdownOpen);
+    }
+
+    [AvaloniaFact]
+    public void Presenter_Time_Change_Updates_SelectedStartTime()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var startTextBox = picker.GetTemplateChildOfType<TextBox>(TimeRangePickerBase.PART_StartTextBox);
+        Assert.NotNull(startTextBox);
+        var position = startTextBox.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+        window.MouseDown(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        var startPresenter = picker.GetTemplateChildOfType<TimePickerPresenter>(TimeRangePickerBase.PART_StartPresenter);
+        Assert.NotNull(startPresenter);
+
+        var newTime = new TimeOnly(9, 15, 0);
+        startPresenter.RaiseEvent(new TimeChangedEventArgs(null, newTime)
+            { RoutedEvent = TimePickerPresenter.SelectedTimeChangedEvent });
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(newTime, picker.SelectedStartTime);
+    }
+
+    [AvaloniaFact]
+    public void Presenter_Time_Change_Updates_SelectedEndTime()
+    {
+        var window = new Window();
+        var picker = CreatePicker();
+        window.Content = picker;
+        window.Show();
+        Dispatcher.UIThread.RunJobs();
+
+        var endTextBox = picker.GetTemplateChildOfType<TextBox>(TimeRangePickerBase.PART_EndTextBox);
+        Assert.NotNull(endTextBox);
+        var position = endTextBox.TranslatePoint(new Point(5, 5), window);
+        Assert.NotNull(position);
+        window.MouseDown(position.Value, MouseButton.Left);
+        Dispatcher.UIThread.RunJobs();
+
+        var endPresenter = picker.GetTemplateChildOfType<TimePickerPresenter>(TimeRangePickerBase.PART_EndPresenter);
+        Assert.NotNull(endPresenter);
+
+        var newTime = new TimeOnly(18, 45, 0);
+        endPresenter.RaiseEvent(new TimeChangedEventArgs(null, newTime)
+            { RoutedEvent = TimePickerPresenter.SelectedTimeChangedEvent });
+        Dispatcher.UIThread.RunJobs();
+
+        Assert.Equal(newTime, picker.SelectedEndTime);
+    }
+}


### PR DESCRIPTION
## Summary

Adds headless tests for the four DateOnly/TimeOnly picker controls that were missing test coverage:

- **DateOnlyPickerTests** (10 tests): popup open/close, button toggle, clear, keyboard navigation (Escape, Down, Tab), TextBox sync, calendar selection
- **TimeOnlyPickerTests** (8 tests): popup open/close, button toggle, clear, TextBox sync, keyboard navigation, presenter-driven time selection
- **DateOnlyRangePickerTests** (7 tests): TextBox sync, clear, start/end TextBox click, Escape closes popup, calendar sequential date selection
- **TimeOnlyRangePickerTests** (7 tests): TextBox sync, clear, start/end TextBox click, Escape closes popup, presenter-driven start/end time updates

All 648 headless tests pass.